### PR TITLE
add share-image command

### DIFF
--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -4,7 +4,7 @@ from moto import mock_ec2
 from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
-from tools.ec2 import launch, describe, stop, terminate, start, modify, delete_image
+from tools.ec2 import launch, describe, stop, terminate, start, modify, delete_image, share_image
 
 
 @pytest.fixture
@@ -81,7 +81,7 @@ def test_modify(mock_aws_configs):
     assert instances[0]["Type"] == "c5.2xlarge"
 
 
-def test_delete_ami(mock_aws_configs):
+def test_delete_image(mock_aws_configs):
     delete_image(mock_aws_configs, AMIS[0]["ami_id"])
 
 
@@ -91,3 +91,8 @@ def test_terminate(mock_aws_configs):
     response = terminate(mock_aws_configs, name="alice")
 
     print(response)
+
+
+def test_share_image(mock_aws_configs):
+    share_image(mock_aws_configs, AMIS[0]["ami_id"], '123456789012')
+

--- a/tools/ec2.py
+++ b/tools/ec2.py
@@ -25,6 +25,26 @@ def delete_image(config, ami: str):
     ec2_client.delete_snapshot(SnapshotId=response[0]['SnapshotId'])
 
 
+@arg('ami', help='ami id')
+@arg('account', help='account id')
+@cli
+def share_image(config, ami: str, account: str):
+    """
+    Share an AMI with another account
+    """
+
+    ec2_client = boto3.client('ec2', region_name=config['region'])
+
+    ec2_client.modify_image_attribute(
+        ImageId=ami,
+        LaunchPermission={"Add": [{"UserId": account}]},
+        OperationType="add",
+        UserIds=[account],
+        Value="string",
+        DryRun=False,
+    )
+
+
 @arg('--ami', help='filter to this ami id', default=None)
 @cli
 def describe_images(config, ami) -> List[Dict[str, Any]]:
@@ -245,7 +265,7 @@ def read_file(filepath) -> AnyStr:
 
 def main():
     parser = argh.ArghParser()
-    parser.add_commands([describe_images, describe, launch, start, stop, terminate, modify, delete_image])
+    parser.add_commands([describe_images, describe, launch, start, stop, terminate, modify, delete_image, share_image])
     parser.dispatch()
 
 


### PR DESCRIPTION
useful when we need to manually share an AMI with another account