### PR TITLE
automatically upgrade venv when requirements change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ venv = ~/.virtualenvs/aec
 python := $(venv)/bin/python
 pip := $(venv)/bin/pip
 
-$(venv): requirements.txt requirements.dev.txt
+$(pip):
+	# create new virtualenv $(venv) containing pip
 	$(if $(value VIRTUAL_ENV),$(error Cannot create a virtualenv when running in a virtualenv. Please deactivate the current virtual env $(VIRTUAL_ENV)),)
-	python3 -m venv --clear $(venv) && $(pip) install -r requirements.txt && $(pip) install -r requirements.dev.txt
+	python3 -m venv --clear $(venv)
+
+$(venv): requirements.txt requirements.dev.txt $(pip)
+	$(pip) install -r requirements.txt && $(pip) install -r requirements.dev.txt
+	touch $(venv)
 
 ## set up python virtualenv (named aec) and install requirements
 venv: $(venv)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -52,7 +52,8 @@ def test_drain_keep(mock_aws_configs):
 def approximate_messages_not_visible(config) -> int:
     sqs_client = boto3.client("sqs", region_name=config["region"])
     resp = sqs_client.get_queue_attributes(
-        QueueUrl=config["queue_url"], AttributeNames=["ApproximateNumberOfMessagesNotVisible"]
+        QueueUrl=config["queue_url"],
+        AttributeNames=["ApproximateNumberOfMessagesNotVisible"],
     )
     print(resp)
     return int(resp["Attributes"]["ApproximateNumberOfMessagesNotVisible"])


### PR DESCRIPTION
When the requirements have changed, then make targets that depend on the virtualenv (eg: test, lint, install, format) will upgrade the virtualenv first.

Before the whole virtualenv was being recreated, which would error when running inside the existing virtualenv. Creating the virtualenv is now split out from upgrading requirements so that its possible to upgrade requirements when make is run within the context of the aec virtualenv.