### PR TITLE
Can specify AssociatePublicIpAddress when launching

### DIFF
--- a/conf/ec2.example.toml
+++ b/conf/ec2.example.toml
@@ -17,7 +17,7 @@ describe_images_owners = "self"
 region = "us-east-1"
 key_name = "my-key-us"
 iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/ec2_my_default"
-vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0123456","sg-7123456789"] }
+vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0123456","sg-7123456789"], associate_public_ip_address = true }
 
 # include these accounts when listing AMIs
 describe_images_owners = [ "self", "123456789012"]

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -36,16 +36,25 @@ def mock_aws_config():
 
 
 def test_launch(mock_aws_config):
-    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"]))
+    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    assert "amazonaws.com" in instances[0]["DnsName"]
 
 
 def test_launch_multiple_security_groups(mock_aws_config):
     mock_aws_config["vpc"]["security_group"] = ["one", "two"]
-    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"],))
+    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"], ))
+
 
 def test_launch_without_instance_profile(mock_aws_config):
     del mock_aws_config["iam_instance_profile_arn"]
-    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"],))
+    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"], ))
+
+
+@pytest.mark.skip(reason="failing because of https://github.com/spulec/moto/pull/2651")
+def test_launch_without_public_ip_address(mock_aws_config):
+    mock_aws_config["vpc"]["associate_public_ip_address"] = False
+    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    assert "ec2.internal" in instances[0]["DnsName"]
 
 
 def test_launch_has_userdata(mock_aws_config):


### PR DESCRIPTION
Subnets have a MapPublicIpOnLaunch attribute which determines whether instances launched in the subnet receive a public ipv4 address by default.

This PR adds the ability to specify AssociatePublicIpAddress when launching, therefore overriding the default set by the subnet's MapPublicIpOnLaunch attribute.

This is handy if the subnet doesn't by default associate a public IP address and you want one for your instance. Note: the subnet also needs an internet gateway for the public IP address to be accessible.