### PR TITLE
Don't show the ghost positional argument args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ extras_dev = open("requirements.dev.txt").read().strip().split("\n")
 
 setup(
     name="aec",
-    version="0.1.2",
+    version="0.2.0",
     description="AWS Easy CLI",
     entry_points={"console_scripts": ["ec2 = tools.ec2:main", "sqs = tools.sqs:main"]},
     python_requires=">=3.6",

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -27,29 +27,29 @@ def mock_aws_config():
 
 
 def test_launch(mock_aws_config):
-    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    instances = launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
     assert "amazonaws.com" in instances[0]["DnsName"]
 
 
 def test_launch_multiple_security_groups(mock_aws_config):
     mock_aws_config["vpc"]["security_group"] = ["one", "two"]
-    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"],))
+    print(launch("alice", AMIS[0]["ami_id"], config=mock_aws_config))
 
 
 def test_launch_without_instance_profile(mock_aws_config):
     del mock_aws_config["iam_instance_profile_arn"]
-    print(launch(mock_aws_config, "alice", AMIS[0]["ami_id"],))
+    print(launch("alice", AMIS[0]["ami_id"], config=mock_aws_config))
 
 
 @pytest.mark.skip(reason="failing because of https://github.com/spulec/moto/pull/2651")
 def test_launch_without_public_ip_address(mock_aws_config):
     mock_aws_config["vpc"]["associate_public_ip_address"] = False
-    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    instances = launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
     assert "ec2.internal" in instances[0]["DnsName"]
 
 
 def test_override_key_name(mock_aws_config):
-    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"], key_name="magic-key")
+    instances = launch("alice", AMIS[0]["ami_id"], key_name="magic-key", config=mock_aws_config)
     instance_id = instances[0]["InstanceId"]
 
     actual_key_name = describe_instance0(mock_aws_config["region"], instance_id)
@@ -59,13 +59,18 @@ def test_override_key_name(mock_aws_config):
 
 def test_launch_has_userdata(mock_aws_config):
     print(
-        launch(mock_aws_config, "test_userdata", AMIS[0]["ami_id"], userdata="conf/userdata/amzn-install-docker.yaml",)
+        launch(
+            "test_userdata",
+            AMIS[0]["ami_id"],
+            userdata="conf/userdata/amzn-install-docker.yaml",
+            config=mock_aws_config,
+        )
     )
 
 
 def test_describe(mock_aws_config):
-    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
-    launch(mock_aws_config, "sam", AMIS[0]["ami_id"])
+    launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
+    launch("sam", AMIS[0]["ami_id"], config=mock_aws_config)
 
     instances = describe(config=mock_aws_config)
     print(instances)
@@ -87,7 +92,7 @@ def test_describe_instance_without_tags(mock_aws_config):
 
 
 def test_describe_by_name(mock_aws_config):
-    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
 
     instances = describe(name="alice", config=mock_aws_config)
     print(instances)
@@ -114,17 +119,17 @@ def test_describe_images(mock_aws_config):
 
 
 def test_stop_start(mock_aws_config):
-    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
 
-    stop(mock_aws_config, name="alice")
+    stop(name="alice", config=mock_aws_config)
 
-    start(mock_aws_config, name="alice")
+    start(name="alice", config=mock_aws_config)
 
 
 def test_modify(mock_aws_config):
-    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
 
-    instances = modify(mock_aws_config, name="alice", type="c5.2xlarge")
+    instances = modify(name="alice", type="c5.2xlarge", config=mock_aws_config)
 
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
@@ -132,16 +137,16 @@ def test_modify(mock_aws_config):
 
 
 def test_delete_image(mock_aws_config):
-    delete_image(mock_aws_config, AMIS[0]["ami_id"])
+    delete_image(AMIS[0]["ami_id"], config=mock_aws_config)
 
 
 def test_terminate(mock_aws_config):
-    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    launch("alice", AMIS[0]["ami_id"], config=mock_aws_config)
 
-    response = terminate(mock_aws_config, name="alice")
+    response = terminate(name="alice", config=mock_aws_config)
 
     print(response)
 
 
 def test_share_image(mock_aws_config):
-    share_image(mock_aws_config, AMIS[0]["ami_id"], "123456789012")
+    share_image(AMIS[0]["ami_id"], "123456789012", config=mock_aws_config)

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -40,12 +40,12 @@ def mock_aws_configs():
 
 
 def test_drain(mock_aws_configs):
-    drain(mock_aws_configs, "/dev/null")
+    drain("/dev/null", config=mock_aws_configs)
     assert approximate_messages_not_visible(mock_aws_configs) == 0
 
 
 def test_drain_keep(mock_aws_configs):
-    drain(mock_aws_configs, "/dev/null", keep=True)
+    drain("/dev/null", keep=True, config=mock_aws_configs)
     assert approximate_messages_not_visible(mock_aws_configs) == 1
 
 

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 from functools import wraps
 
@@ -23,21 +24,29 @@ class Cli:
         """
 
         @wraps(func)
-        @arg("--profile", help="Profile in the config file to use", default="default")
+        @arg("--config", help="Section of the config file to use")
         def wrapper(*args, **kwargs):
             # print(args)
             # print(kwargs)
 
-            # we are being called from tests, or by other functions, just pass through
-            if args or isinstance(kwargs.get("config", None), dict):
+            # config is always the final arg
+            CONFIG_ARG_INDEX = -1
+
+            # if arg/kwargs contain the config dict then we are being called from tests,
+            # or by other functions, so just pass through
+            if (args and isinstance(args[CONFIG_ARG_INDEX], dict)) or isinstance(kwargs.get("config", None), dict):
                 return func(*args, **kwargs)
 
-            # we are being called from the cli, so load the config and prettify the result
-            profile = kwargs.pop("config")
-            kwargs["config"] = load_config(self.config_file, profile)
+            # here we are being called from the cli
 
-            result = func(*args, **kwargs)
+            # load the config and pass it to the function
+            profile = args[CONFIG_ARG_INDEX]
+            config = load_config(self.config_file, profile)
 
+            args_without_config = args[:1]
+            result = func(*args_without_config, config, **kwargs)
+
+            # prettify the result
             if isinstance(result, list):
                 prettified = pretty_table(as_table(result))
                 return prettified if prettified else "No results"
@@ -45,5 +54,8 @@ class Cli:
                 return json.dumps(result, default=str)
             else:
                 return result
+
+        # prevent argh help from displaying a positional args param
+        wrapper.__signature__ = inspect.signature(func)
 
         return wrapper

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -29,11 +29,11 @@ class Cli:
             # print(kwargs)
 
             # we are being called from tests, or by other functions, just pass through
-            if args or "config" in kwargs:
+            if args or isinstance(kwargs.get("config", None), dict):
                 return func(*args, **kwargs)
 
             # we are being called from the cli, so load the config and prettify the result
-            profile = kwargs.pop("profile", "default")
+            profile = kwargs.pop("config")
             kwargs["config"] = load_config(self.config_file, profile)
 
             result = func(*args, **kwargs)

--- a/tools/config.py
+++ b/tools/config.py
@@ -6,7 +6,7 @@ import pytoml as toml
 
 
 # TODO add tests for this
-def load_config(config_file: str, profile: str = "default"):
+def load_config(config_file: str, profile: str = None):
     """
     Load profile from the config file.
 
@@ -18,7 +18,7 @@ def load_config(config_file: str, profile: str = "default"):
     config = load_user_config_file(config_filepath)
 
     # set profile to the value of the default key
-    if profile == "default":
+    if not profile:
         if "default_profile" not in config:
             print(
                 f"No profile supplied, or default profile set in {config_filepath}", file=sys.stderr,

--- a/tools/ec2.py
+++ b/tools/ec2.py
@@ -12,11 +12,11 @@ cli = Cli(config_file="~/.aec/ec2.toml").cli
 
 @arg("ami", help="ami id")
 @cli
-def delete_image(config, ami: str):
+def delete_image(ami: str, config: Dict[str, Any] = None):
     """Deregister an AMI and deletes its snapshot."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
-    response = describe_images(config, ami)
+    response = describe_images(ami, config)
 
     ec2_client.deregister_image(ImageId=ami)
 
@@ -26,7 +26,7 @@ def delete_image(config, ami: str):
 @arg("ami", help="ami id")
 @arg("account", help="account id")
 @cli
-def share_image(config, ami: str, account: str):
+def share_image(ami: str, account: str, config: Dict[str, Any] = None):
     """Share an AMI with another account."""
 
     ec2_client = boto3.client("ec2", region_name=config["region"])
@@ -43,7 +43,7 @@ def share_image(config, ami: str, account: str):
 
 @arg("--ami", help="filter to this ami id", default=None)
 @cli
-def describe_images(config, ami: str = None) -> List[Dict[str, Any]]:
+def describe_images(ami: str = None, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """List AMIs."""
 
     ec2_client = boto3.client("ec2", region_name=config["region"])
@@ -84,7 +84,6 @@ root_devices = {"amazon": "/dev/xvda", "ubuntu": "/dev/sda1"}
 @arg("--userdata", help="path to user data file", default=None)
 @cli
 def launch(
-    config,
     name: str,
     ami: str,
     dist: str = "amazon",
@@ -92,6 +91,7 @@ def launch(
     instance_type="t2.medium",
     key_name=None,
     userdata=None,
+    config: Dict[str, Any] = None,
 ) -> List[Dict[str, Any]]:
     """Launch a tagged EC2 instance with an EBS volume."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
@@ -157,12 +157,12 @@ def launch(
 
     # the response from run_instances above always contains an empty string
     # for PublicDnsName, so we call describe to get it
-    return describe(config, name=name)
+    return describe(name=name, config=config)
 
 
 @arg("--name", help="Filter to hosts with this Name tag", default=None)
 @cli
-def describe(config, name=None) -> List[Dict[str, Any]]:
+def describe(name=None, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """List EC2 instances in the region."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
@@ -190,13 +190,13 @@ def describe(config, name=None) -> List[Dict[str, Any]]:
 
 @arg("name", help="Name tag of instance")
 @cli
-def start(config, name) -> List[Dict[str, Any]]:
+def start(name, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """Start EC2 instances by name."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
     print(f"Starting instances with the name {name} ... ")
 
-    instances = describe(config, name)
+    instances = describe(name, config)
 
     if not instances:
         raise Exception(f"No instances named {name}")
@@ -207,16 +207,16 @@ def start(config, name) -> List[Dict[str, Any]]:
     waiter = ec2_client.get_waiter("instance_running")
     waiter.wait(InstanceIds=instance_ids)
 
-    return describe(config, name)
+    return describe(name, config)
 
 
 @arg("name", help="Name tag")
 @cli
-def stop(config, name) -> List[Dict[str, Any]]:
+def stop(name, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """Stop EC2 instances by name."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
-    instances = describe(config, name)
+    instances = describe(name, config)
 
     if not instances:
         raise Exception(f"No instances named {name}")
@@ -228,11 +228,11 @@ def stop(config, name) -> List[Dict[str, Any]]:
 
 @arg("name", help="Name tag of instance")
 @cli
-def terminate(config, name) -> List[Dict[str, Any]]:
+def terminate(name, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """Terminate EC2 instances by name."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
-    instances = describe(config, name)
+    instances = describe(name, config)
 
     if not instances:
         raise Exception(f"No instances named {name}")
@@ -247,11 +247,11 @@ def terminate(config, name) -> List[Dict[str, Any]]:
 @arg("name", help="Name tag of instance")
 @arg("type", help="Type of instance")
 @cli
-def modify(config, name, type) -> List[Dict[str, Any]]:
+def modify(name, type, config: Dict[str, Any] = None) -> List[Dict[str, Any]]:
     """Change an instance's type."""
     ec2_client = boto3.client("ec2", region_name=config["region"])
 
-    instances = describe(config, name)
+    instances = describe(name, config)
 
     if not instances:
         raise Exception(f"No instances named {name}")
@@ -259,7 +259,7 @@ def modify(config, name, type) -> List[Dict[str, Any]]:
     instance_id = instances[0]["InstanceId"]
     ec2_client.modify_instance_attribute(InstanceId=instance_id, InstanceType={"Value": type})
 
-    return describe(config, name)
+    return describe(name, config)
 
 
 def first_or_else(l: List[Any], default: Any) -> Any:

--- a/tools/sqs.py
+++ b/tools/sqs.py
@@ -1,6 +1,7 @@
 import json
 import os.path
 import sys
+from typing import Any, Dict
 
 import argh
 import boto3
@@ -18,7 +19,7 @@ cli = Cli(config_file="~/.aec/sqs.toml").cli
 @arg("file_name", help="file to write messages to")
 @arg("--keep", help="keep messages, don't delete them", default=False)
 @cli
-def drain(config, file_name, keep=False):
+def drain(file_name, keep=False, config: Dict[str, Any] = None):
     """Receive messages from the configured queue and write them to a file, pretty print them to stdout and then delete
     them from the queue."""
     queue_url = config["queue_url"]


### PR DESCRIPTION
Don't show the ghost positional argument `args`
(fixes #145)

This is fixed by:
```
wrapper.__signature__ = inspect.signature(func)
```
But in doing so it forces all @arg decorators to reference arguments in
the function signature. Therefore `--profile` can't exist because it
doesn't match a function argument. It has been renamed to `--config`.
Also, because `--config` is optional on the CLI, the function argument
needs to provide a default even though it's mandatory for the function.
Because python syntax doesn't allow non-default arguments to follow
default arguments it has been moved to be the last argument.

