### PR TITLE
feature: add over-provisioned recommendations

### DIFF
--- a/.install-typings-boto3.sh
+++ b/.install-typings-boto3.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -uoe pipefail
+
+function die() {
+    >&2 echo -e "$@"
+    exit 1
+}
+
+[[ -z "${VIRTUAL_ENV:-}" ]] && die "Please activate the virtualenv first"
+
+"$VIRTUAL_ENV"/bin/python -m mypy_boto3
+
+# workaround for https://github.com/vemel/mypy_boto3_builder/issues/39
+# install overloads for implicit type inference on boto3.client/boto3.resource
+mkdir -p typings/boto3
+cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/boto3_init_gen.py typings/boto3/__init__.pyi
+
+for d in "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/[!_]*/
+do
+    service=$(basename "$d")
+    echo "$service"
+ls 
+    mkdir -p typings/mypy_boto3/"$service"
+    mkdir -p typings/mypy_boto3_"$service"
+    for f in __init__ client paginator service_resource waiter type_defs; do
+        # install generated stubs used by the overloads
+        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/"$service"/$f.py typings/mypy_boto3/"$service"/$f.pyi
+
+        # install packaged stubs for explicit type annotation (also used by the generated stubs)
+        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_"$service"/$f.py typings/mypy_boto3_"$service"/$f.pyi
+    done
+done
+
+
+# for service in $VIRTUAL_ENV/lib/python*/site-packages/mypy_boto3_*/
+# do
+#     case $service in
+#         *.dist-info/) ;; # ignore
+#         *) basename $service
+#     esac
+# done
+
+# exit 0
+
+
+
+
+
+
+# mkdir -p typings/mypy_boto3_ec2
+# for f in __init__ client paginator service_resource waiter type_defs; do
+#     cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_ec2/$f.py typings/mypy_boto3_ec2/$f.pyi
+# done

--- a/.install-typings-boto3.sh
+++ b/.install-typings-boto3.sh
@@ -19,16 +19,18 @@ cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/boto3_init_gen.py typings
 for d in "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/[!_]*/
 do
     service=$(basename "$d")
-    echo "$service"
-ls 
+    echo "Installing pyright stubs into typings/ for $service"
+ 
     mkdir -p typings/mypy_boto3/"$service"
     mkdir -p typings/mypy_boto3_"$service"
-    for f in __init__ client paginator service_resource waiter type_defs; do
+    for f in "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/"$service"/*.py; do
+        module=$(basename -s .py "$f")
+
         # install generated stubs used by the overloads
-        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/"$service"/$f.py typings/mypy_boto3/"$service"/$f.pyi
+        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/"$service"/"$module".py typings/mypy_boto3/"$service"/"$module".pyi
 
         # install packaged stubs for explicit type annotation (also used by the generated stubs)
-        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_"$service"/$f.py typings/mypy_boto3_"$service"/$f.pyi
+        cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_"$service"/"$module".py typings/mypy_boto3_"$service"/"$module".pyi
     done
 done
 
@@ -41,11 +43,7 @@ done
 #     esac
 # done
 
-# exit 0
-
-
-
-
+# exit 
 
 
 # mkdir -p typings/mypy_boto3_ec2

--- a/.install-typings-boto3.sh
+++ b/.install-typings-boto3.sh
@@ -33,20 +33,3 @@ do
         cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_"$service"/"$module".py typings/mypy_boto3_"$service"/"$module".pyi
     done
 done
-
-
-# for service in $VIRTUAL_ENV/lib/python*/site-packages/mypy_boto3_*/
-# do
-#     case $service in
-#         *.dist-info/) ;; # ignore
-#         *) basename $service
-#     esac
-# done
-
-# exit 
-
-
-# mkdir -p typings/mypy_boto3_ec2
-# for f in __init__ client paginator service_resource waiter type_defs; do
-#     cp "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3_ec2/$f.py typings/mypy_boto3_ec2/$f.pyi
-# done

--- a/.install-typings-boto3.sh
+++ b/.install-typings-boto3.sh
@@ -20,7 +20,7 @@ for d in "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/[!_]*/
 do
     service=$(basename "$d")
     echo "Installing pyright stubs into typings/ for $service"
- 
+
     mkdir -p typings/mypy_boto3/"$service"
     mkdir -p typings/mypy_boto3_"$service"
     for f in "$VIRTUAL_ENV"/lib/python*/site-packages/mypy_boto3/"$service"/*.py; do

--- a/Makefile
+++ b/Makefile
@@ -25,23 +25,7 @@ $(venv): requirements.* setup.py $(pip)
 # install pyright stubs
 typings: $(venv)
 	rm -rf typings/
-
-	$(venv)/bin/python -m mypy_boto3
-
-	# workaround for https://github.com/vemel/mypy_boto3_builder/issues/39
-	mkdir -p typings/boto3
-	cp $(venv)/lib/python*/site-packages/mypy_boto3/boto3_init_gen.py typings/boto3/__init__.pyi
-
-	# install generated stubs for implicit type inference on boto3.client/boto3.resource
-	mkdir -p typings/mypy_boto3/ec2
-	for f in __init__ client paginator service_resource waiter type_defs; do \
-		cp $(venv)/lib/python*/site-packages/mypy_boto3/ec2/$$f.py typings/mypy_boto3/ec2/$$f.pyi; done
-
-	# install packaged stubs for explicit type annotation (also used by the generated stubs)
-	mkdir -p typings/mypy_boto3_ec2
-	for f in __init__ client paginator service_resource waiter type_defs; do \
-		cp $(venv)/lib/python*/site-packages/mypy_boto3_ec2/$$f.py typings/mypy_boto3_ec2/$$f.pyi; done
-
+	VIRTUAL_ENV=$(venv) ./.install-typings-boto3.sh
 	touch typings
 
 ## create venv, install this package in dev mode, create stubs, and install hooks (if not in CI)

--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ CLI tools for doing things on AWS easier. Defaults (eg: subnet, tags etc.) only 
 
 Currently supports the following AWS services:
 
-* [EC2](docs/ec2.md) - manipulate EC2 instances by name, and launch them with EBS volumes of any size, as per the settings in the configuration file (subnet, tags etc).
-* [SQS](docs/sqs.md) - drain configured SQS queues to a file, pretty printing deleted messages using a jq filter
-* [Compute Optimizer](docs/compute-optimizer.md) - show over-provisioned instances
+- [EC2](docs/ec2.md) - manipulate EC2 instances by name, and launch them with EBS volumes of any size, as per the settings in the configuration file (subnet, tags etc).
+- [SQS](docs/sqs.md) - drain configured SQS queues to a file, pretty printing deleted messages using a jq filter
+- [Compute Optimizer](docs/compute-optimizer.md) - show over-provisioned instances
 
 ## Prerequisites
 
-* python 3.7+
-* pip3
-* automake & libtool:  
-  * Ubuntu: `sudo apt install automake libtool`
-  * macOS: `brew install automake libtool`
+- python 3.7+
+- pip3
+- automake & libtool:
+  - Ubuntu: `sudo apt install automake libtool`
+  - macOS: `brew install automake libtool`
 
 ## Install
 
@@ -46,13 +46,15 @@ alias sqs='aec sqs'
 ## Development
 
 Pre-reqs:
-* make
-* node (required for pyright)
+
+- make
+- node (required for pyright)
 
 To get started run `make install`. This will:
-* install git hooks for formatting & linting on git push
-* create the virtualenv
-* install this package in editable mode
+
+- install git hooks for formatting & linting on git push
+- create the virtualenv
+- install this package in editable mode
 
 Then run `make` to see the options for running checks, tests etc.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supports the following AWS services:
 
 * [EC2](docs/ec2.md) - manipulate EC2 instances by name, and launch them with EBS volumes of any size, as per the settings in the configuration file (subnet, tags etc).
 * [SQS](docs/sqs.md) - drain configured SQS queues to a file, pretty printing deleted messages using a jq filter
+* [Compute Optimizer](docs/compute-optimizer.md) - show over-provisioned instances
 
 ## Prerequisites
 

--- a/aec/compute_optimizer.py
+++ b/aec/compute_optimizer.py
@@ -4,7 +4,7 @@ import boto3
 
 
 def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Return recommendations for over-provisioned EC2 instances."""
+    """Show recommendations for over-provisioned EC2 instances."""
 
     client = boto3.client("compute-optimizer", region_name=config["region"])
 

--- a/aec/compute_optimizer.py
+++ b/aec/compute_optimizer.py
@@ -1,9 +1,10 @@
 from typing import Any, Dict, List
+
 import boto3
 
 
 def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """ Return recommendations for over-provisioned EC2 instances. """
+    """Return recommendations for over-provisioned EC2 instances."""
 
     client = boto3.client("compute-optimizer", region_name=config["region"])
 
@@ -14,7 +15,7 @@ def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             "ID": i["instanceArn"].split("/")[1],
             "Name": i.get("instanceName", None),
             "Instance Type": i["currentInstanceType"],
-            "Recommendation": i["recommendationOptions"][0]["instanceType"]
+            "Recommendation": i["recommendationOptions"][0]["instanceType"],
         }
         for i in response["instanceRecommendations"]
     ]

--- a/aec/compute_optimizer.py
+++ b/aec/compute_optimizer.py
@@ -1,0 +1,22 @@
+from typing import Any, Dict, List
+import boto3
+
+
+def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """ Return recommendations for over-provisioned EC2 instances. """
+
+    client = boto3.client("compute-optimizer", region_name=config["region"])
+
+    response = client.get_ec2_instance_recommendations(filters=[{"name": "Finding", "values": ["Overprovisioned"]}])
+
+    recs = [
+        {
+            "ID": i["instanceArn"].split("/")[1],
+            "Name": i.get("instanceName", None),
+            "Instance Type": i["currentInstanceType"],
+            "Recommendation": i["recommendationOptions"][0]["instanceType"]
+        }
+        for i in response["instanceRecommendations"]
+    ]
+
+    return recs

--- a/aec/compute_optimizer.py
+++ b/aec/compute_optimizer.py
@@ -1,10 +1,14 @@
 from typing import Any, Dict, List
 
 import boto3
+from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
 
 
 def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Show recommendations for over-provisioned EC2 instances."""
+
+    def util(metric: UtilizationMetricTypeDef) -> str:
+        return f'{metric["name"]} {metric["statistic"][:3]} {metric["value"]}'
 
     client = boto3.client("compute-optimizer", region_name=config["region"])
 
@@ -16,6 +20,7 @@ def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             "Name": i.get("instanceName", None),
             "Instance Type": i["currentInstanceType"],
             "Recommendation": i["recommendationOptions"][0]["instanceType"],
+            "Utilization": util(i["utilizationMetrics"][0]),
         }
         for i in response["instanceRecommendations"]
     ]

--- a/aec/display.py
+++ b/aec/display.py
@@ -74,6 +74,6 @@ def pretty_print(result):
 
         console.print(table)
     elif isinstance(result, dict):
-        console.print(json.dumps(result, default=str))
+        print(json.dumps(result, default=str))
     else:
-        console.print(result)
+        print(result)

--- a/aec/main.py
+++ b/aec/main.py
@@ -3,12 +3,12 @@ import sys
 from typing import List
 
 import aec.cli as cli
+import aec.compute_optimizer as compute_optimizer
 import aec.config as config
 import aec.configure as configure
 import aec.display as display
 import aec.ec2 as ec2
 import aec.sqs as sqs
-import aec.compute_optimizer as compute_optimizer
 from aec.cli import Arg, Cmd
 
 config_arg = Arg("--config", help="Section of the config file to use")
@@ -90,7 +90,13 @@ def build_parser() -> argparse.ArgumentParser:
     cli.add_command_group(subparsers, "configure", "Configure subcommands", configure_cli)
     cli.add_command_group(subparsers, "ec2", "EC2 subcommands", ec2_cli, config.inject_config("~/.aec/ec2.toml"))
     cli.add_command_group(subparsers, "sqs", "SQS subcommands", sqs_cli, config.inject_config("~/.aec/sqs.toml"))
-    cli.add_command_group(subparsers, "co", "Compute optimizer subcommands", compute_optimizer_cli, config.inject_config("~/.aec/ec2.toml"))
+    cli.add_command_group(
+        subparsers,
+        "co",
+        "Compute optimizer subcommands",
+        compute_optimizer_cli,
+        config.inject_config("~/.aec/ec2.toml"),
+    )
 
     return parser
 

--- a/aec/main.py
+++ b/aec/main.py
@@ -8,6 +8,7 @@ import aec.configure as configure
 import aec.display as display
 import aec.ec2 as ec2
 import aec.sqs as sqs
+import aec.compute_optimizer as compute_optimizer
 from aec.cli import Arg, Cmd
 
 config_arg = Arg("--config", help="Section of the config file to use")
@@ -73,6 +74,12 @@ sqs_cli = [
         Arg("--keep", type=str, help="Keep messages, don't delete them", default=False)
     ])
 ]
+
+compute_optimizer_cli = [
+    Cmd(compute_optimizer.over_provisioned, [
+        config_arg
+    ])
+]
 # fmt: on
 
 
@@ -83,6 +90,7 @@ def build_parser() -> argparse.ArgumentParser:
     cli.add_command_group(subparsers, "configure", "Configure subcommands", configure_cli)
     cli.add_command_group(subparsers, "ec2", "EC2 subcommands", ec2_cli, config.inject_config("~/.aec/ec2.toml"))
     cli.add_command_group(subparsers, "sqs", "SQS subcommands", sqs_cli, config.inject_config("~/.aec/sqs.toml"))
+    cli.add_command_group(subparsers, "co", "Compute optimizer subcommands", compute_optimizer_cli, config.inject_config("~/.aec/ec2.toml"))
 
     return parser
 

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -13,7 +13,7 @@ subcommands:
     over-provisioned  Show recommendations for over-provisioned EC2 instances.
 ```
 
-To show recommendations for over-provisioned instanctes:
+To show recommendations for over-provisioned instances:
 
 ```
 $ aec co over-provisioned

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -18,10 +18,10 @@ To show recommendations for over-provisioned instances (eg: idle instances runni
 ```
 $ aec co over-provisioned
 
-  ID                    Name                                            Instance Type   Recommendation   Utilization
- ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-01579de1b005846cb   instance A                                      m5.4xlarge      r5.2xlarge       CPU MAX 4.0
-  i-070c800a592bc6d73   instance B                                      m5.large        t3.large         CPU MAX 47.0
-  i-0ad199cc5b65c621d   instance C                                      m5.xlarge       r5.large         CPU MAX 4.0
+  ID                    Name         Instance Type   Recommendation   Utilization
+ ─────────────────────────────────────────────────────────────────────────────────
+  i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0
+  i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0
+  i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 4.0
 
 ```

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -13,14 +13,15 @@ subcommands:
     over-provisioned  Show recommendations for over-provisioned EC2 instances.
 ```
 
-To show recommendations for over-provisioned instances:
+To show recommendations for over-provisioned instances (eg: idle instances running for more than 30 hours):
 
 ```
 $ aec co over-provisioned
 
-  ID                    Name                                            Instance Type   Recommendation
- ──────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-01579de1b005846cb   instance A                                       m5.4xlarge      r5.2xlarge
-  i-070c800a592bc6d73   instance B                                       m5.xlarge       r5.large
-  i-0ad199cc5b65c621d   instance C                                       m5.xlarge       t3.xlarge
+  ID                    Name                                            Instance Type   Recommendation   Utilization
+ ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  i-01579de1b005846cb   instance A                                      m5.4xlarge      r5.2xlarge       CPU MAX 4.0
+  i-070c800a592bc6d73   instance B                                      m5.large        t3.large         CPU MAX 47.0
+  i-0ad199cc5b65c621d   instance C                                      m5.xlarge       r5.large         CPU MAX 4.0
+
 ```

--- a/docs/compute-optimzer.md
+++ b/docs/compute-optimzer.md
@@ -1,0 +1,26 @@
+# Compute Optimizer Usage
+
+To see the help, run `aec co -h`
+
+```
+usage: aec co [-h] {over-provisioned} ...
+
+optional arguments:
+  -h, --help          show this help message and exit
+
+subcommands:
+  {over-provisioned}
+    over-provisioned  Show recommendations for over-provisioned EC2 instances.
+```
+
+To show recommendations for over-provisioned instanctes:
+
+```
+$ aec co over-provisioned
+
+  ID                    Name                                            Instance Type   Recommendation
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────
+  i-01579de1b005846cb   instance A                                       m5.4xlarge      r5.2xlarge
+  i-070c800a592bc6d73   instance B                                       m5.xlarge       r5.large
+  i-0ad199cc5b65c621d   instance C                                       m5.xlarge       t3.xlarge
+```

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -30,7 +30,7 @@ aec ec2 describe-images
 To launch a t2.medium instance named `lady gaga` with a 100gb EBS volume, with other settings read from the config file
 
 ```
-aec ec2 launch "lady gaga" ami-0bfe6b818fce462af --instance-type t2.medium --volume-size 100  
+aec ec2 launch "lady gaga" ami-0bfe6b818fce462af --instance-type t2.medium --volume-size 100
 ```
 
 Stop the instance
@@ -42,5 +42,5 @@ aec ec2 stop "lady gaga"
 By default, commands will use the default profile as specified in the config file. To list ec2 instances using the non-default config `us`
 
 ```
-aec ec2 describe --config us  
+aec ec2 describe --config us
 ```

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -24,23 +24,23 @@ subcommands:
 To list AMIs (owned by accounts specified in the config file)
 
 ```
-ec2 describe-images
+aec ec2 describe-images
 ```
 
 To launch a t2.medium instance named `lady gaga` with a 100gb EBS volume, with other settings read from the config file
 
 ```
-ec2 launch "lady gaga" ami-0bfe6b818fce462af --instance-type t2.medium --volume-size 100  
+aec ec2 launch "lady gaga" ami-0bfe6b818fce462af --instance-type t2.medium --volume-size 100  
 ```
 
 Stop the instance
 
 ```
-ec2 stop "lady gaga"
+aec ec2 stop "lady gaga"
 ```
 
 By default, commands will use the default profile as specified in the config file. To list ec2 instances using the non-default config `us`
 
 ```
-ec2 describe --config us  
+aec ec2 describe --config us  
 ```

--- a/docs/sqs.md
+++ b/docs/sqs.md
@@ -16,7 +16,7 @@ subcommands:
 To drain the queue configured in the `app1` profile to `dlq.txt`, pretty printing the deleted messages:
 
 ```
-$ sqs drain --profile app1 dlq.txt
+$ aec sqs drain --profile app1 dlq.txt
 822167373.json	RequestId: 393e79a4-cee5-423f-8273-8ea10f1a1fc6 Process exited before completing request
 Drained 1 messages.
 ```

--- a/requirements.node.dev.txt
+++ b/requirements.node.dev.txt
@@ -1,1 +1,1 @@
-pyright@1.1.64
+pyright@1.1.65

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3-stubs[ec2,sqs]==1.14.46.0
+boto3-stubs[ec2,sqs,compute-optimizer]==1.14.46.0
 pyjq==2.4.0
 pytoml==0.1.21
 rich==5.2.1

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -13,7 +13,6 @@ def mock_aws_configs():
     region = "ap-southeast-2"
     sqs = boto3.resource("sqs", region_name=region)
 
-    # pylint: disable=maybe-no-member
     queue = sqs.create_queue(QueueName="test-queue")
 
     queue.send_message(

--- a/toast.yml
+++ b/toast.yml
@@ -23,7 +23,6 @@ tasks:
     input_paths:
       - setup.py
       - pyproject.toml
-      - .pylintrc
       - tests
       - aec
       - conf


### PR DESCRIPTION
# Compute Optimizer Usage

To see the help, run `aec co -h`

```
usage: aec co [-h] {over-provisioned} ...

optional arguments:
  -h, --help          show this help message and exit

subcommands:
  {over-provisioned}
    over-provisioned  Show recommendations for over-provisioned EC2 instances.
```

To show recommendations for over-provisioned instances (eg: idle instances running for more than 30 hours):

```
$ aec co over-provisioned

  ID                    Name         Instance Type   Recommendation   Utilization
 ─────────────────────────────────────────────────────────────────────────────────
  i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0
  i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0
  i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 4.0

```

