### PR TITLE
feature: aec ssm describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently supports the following AWS services:
 - [EC2](docs/ec2.md) - manipulate EC2 instances by name, and launch them with EBS volumes of any size, as per the settings in the configuration file (subnet, tags etc).
 - [SQS](docs/sqs.md) - drain configured SQS queues to a file, pretty printing deleted messages using a jq filter
 - [Compute Optimizer](docs/compute-optimizer.md) - show over-provisioned instances
+- [SSM](docs/ssm.md) - describe SSM agent info
 
 ## Prerequisites
 

--- a/aec/command/ec2.py
+++ b/aec/command/ec2.py
@@ -1,6 +1,6 @@
 import os
 import os.path
-from typing import Any, AnyStr, Dict, List, Optional, TypeVar, Union
+from typing import Any, AnyStr, Dict, List, Optional, TypeVar, Union, cast
 
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
@@ -185,6 +185,21 @@ def describe(config: Dict[str, Any], name: Optional[str] = None) -> List[Dict[st
     ]
 
     return sorted(instances, key=lambda i: i["State"] + str(i["Name"]))
+
+def describe_instances_names(config: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """List EC2 instance names in the region."""
+
+    ec2_client = boto3.client("ec2", region_name=config["region"])
+
+    response = ec2_client.describe_instances()
+
+    instances = {
+        i["InstanceId"]: first_or_else([t["Value"] for t in i.get("Tags", []) if t["Key"] == "Name"], None)
+        for r in response["Reservations"]
+        for i in r["Instances"]
+    }
+
+    return instances
 
 
 def start(config: Dict[str, Any], name: str) -> List[Dict[str, Any]]:

--- a/aec/command/ec2.py
+++ b/aec/command/ec2.py
@@ -1,6 +1,6 @@
 import os
 import os.path
-from typing import Any, AnyStr, Dict, List, Optional, TypeVar, Union, cast
+from typing import Any, AnyStr, Dict, List, Optional, TypeVar, Union
 
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
@@ -185,6 +185,7 @@ def describe(config: Dict[str, Any], name: Optional[str] = None) -> List[Dict[st
     ]
 
     return sorted(instances, key=lambda i: i["State"] + str(i["Name"]))
+
 
 def describe_instances_names(config: Dict[str, Any]) -> Dict[str, Optional[str]]:
     """List EC2 instance names in the region."""

--- a/aec/command/ssm.py
+++ b/aec/command/ssm.py
@@ -5,7 +5,7 @@ import aec.command.ec2 as ec2
 
 
 def describe(config: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Describe instances with the SSM agent."""
+    """Describe instances running the SSM agent."""
 
     instances_names = ec2.describe_instances_names(config)
 

--- a/aec/command/ssm.py
+++ b/aec/command/ssm.py
@@ -1,10 +1,13 @@
 from typing import Any, Dict, List
 
 import boto3
+import aec.command.ec2 as ec2
 
 
 def describe(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Describe instances with the SSM agent."""
+
+    instances_names = ec2.describe_instances_names(config)
 
     client = boto3.client("ssm", region_name=config["region"])
 
@@ -13,9 +16,10 @@ def describe(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     instances = [
         {
             "ID": i["InstanceId"],
+            "Name": instances_names.get(i["InstanceId"], None),
             "PingStatus": i["PingStatus"],
-            "PlatformName": i["PlatformName"],
-            "PlatformVersion": i["PlatformVersion"],
+            "Platform": f'{i["PlatformName"]} {i["PlatformVersion"]}',
+            "AgentVersion": i["AgentVersion"],
         }
         for i in response["InstanceInformationList"]
     ]

--- a/aec/command/ssm.py
+++ b/aec/command/ssm.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict, List
+
+import boto3
+
+
+def describe(config: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Describe instances with the SSM agent."""
+
+    client = boto3.client("ssm", region_name=config["region"])
+
+    response = client.describe_instance_information()
+
+    instances = [
+        {
+            "ID": i["InstanceId"],
+            "PingStatus": i["PingStatus"],
+            "PlatformName": i["PlatformName"],
+            "PlatformVersion": i["PlatformVersion"],
+        }
+        for i in response["InstanceInformationList"]
+    ]
+
+    return instances
+

--- a/aec/command/ssm.py
+++ b/aec/command/ssm.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, List
 
 import boto3
+
 import aec.command.ec2 as ec2
 
 
@@ -25,4 +26,3 @@ def describe(config: Dict[str, Any]) -> List[Dict[str, Any]]:
     ]
 
     return instances
-

--- a/aec/main.py
+++ b/aec/main.py
@@ -3,6 +3,7 @@ import sys
 from typing import List
 
 import aec.command.compute_optimizer as compute_optimizer
+import aec.command.ssm as ssm
 import aec.command.ec2 as ec2
 import aec.command.sqs as sqs
 import aec.util.cli as cli
@@ -80,6 +81,12 @@ compute_optimizer_cli = [
         config_arg
     ])
 ]
+
+ssm_cli = [
+    Cmd(ssm.describe, [
+        config_arg
+    ])
+]
 # fmt: on
 
 
@@ -97,6 +104,7 @@ def build_parser() -> argparse.ArgumentParser:
         compute_optimizer_cli,
         config.inject_config("~/.aec/ec2.toml"),
     )
+    cli.add_command_group(subparsers, "ssm", "SSM subcommands", ssm_cli, config.inject_config("~/.aec/ec2.toml"))
 
     return parser
 

--- a/aec/main.py
+++ b/aec/main.py
@@ -3,9 +3,9 @@ import sys
 from typing import List
 
 import aec.command.compute_optimizer as compute_optimizer
-import aec.command.ssm as ssm
 import aec.command.ec2 as ec2
 import aec.command.sqs as sqs
+import aec.command.ssm as ssm
 import aec.util.cli as cli
 import aec.util.config as config
 import aec.util.configure as configure

--- a/docs/ssm.md
+++ b/docs/ssm.md
@@ -1,0 +1,25 @@
+# SSM Usage
+
+To see the help, run `aec ssm -h`
+
+```
+usage: aec ssm [-h] {describe} ...
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+subcommands:
+  {describe}
+    describe  Describe instances running the SSM agent.
+```
+
+Example:
+
+```
+$ aec ssm describe
+
+  ID                    Name                   PingStatus   Platform         AgentVersion
+ ─────────────────────────────────────────────────────────────────────────────────────────
+  i-01579de1b005846cb   awesome-instance       Online       Amazon Linux 2   2.3.1319.0
+  i-0f194c8d697f35240   even-better-instance   Online       Ubuntu 20.04     2.3.978.0
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3-stubs[ec2,sqs,compute-optimizer]==1.14.46.0
+boto3-stubs[ec2,sqs,compute-optimizer,ssm]==1.14.46.0
 pyjq==2.4.0
 pytoml==0.1.21
 rich==5.2.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.4.3",
+    version="0.4.4",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# SSM Usage

To see the help, run `aec ssm -h`

```
usage: aec ssm [-h] {describe} ...

optional arguments:
  -h, --help  show this help message and exit

subcommands:
  {describe}
    describe  Describe instances running the SSM agent.
```

Example:

```
$ aec ssm describe

  ID                    Name                   PingStatus   Platform         AgentVersion
 ─────────────────────────────────────────────────────────────────────────────────────────
  i-01579de1b005846cb   awesome-instance       Online       Amazon Linux 2   2.3.1319.0
  i-0f194c8d697f35240   even-better-instance   Online       Ubuntu 20.04     2.3.978.0
```
