### PR TITLE
feature: co - add uptime

### DIFF
--- a/aec/command/compute_optimizer.py
+++ b/aec/command/compute_optimizer.py
@@ -1,10 +1,10 @@
+from datetime import datetime
 from typing import Any, Dict, List
 
 import boto3
-from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
 import pytz
-from datetime import datetime
 from dateutil import relativedelta
+from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
 
 
 def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -68,4 +68,3 @@ def difference_in_words(date1: datetime, date2: datetime) -> str:
             words = f"{difference.seconds} seconds"
 
     return words
-

--- a/aec/command/compute_optimizer.py
+++ b/aec/command/compute_optimizer.py
@@ -2,6 +2,9 @@ from typing import Any, Dict, List
 
 import boto3
 from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
+import pytz
+from datetime import datetime
+from dateutil import relativedelta
 
 
 def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -9,6 +12,8 @@ def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
 
     def util(metric: UtilizationMetricTypeDef) -> str:
         return f'{metric["name"]} {metric["statistic"][:3]} {metric["value"]}'
+
+    instances_uptime = describe_instances_uptime(config)
 
     client = boto3.client("compute-optimizer", region_name=config["region"])
 
@@ -21,8 +26,46 @@ def over_provisioned(config: Dict[str, Any]) -> List[Dict[str, Any]]:
             "Instance Type": i["currentInstanceType"],
             "Recommendation": i["recommendationOptions"][0]["instanceType"],
             "Utilization": util(i["utilizationMetrics"][0]),
+            "Uptime": instances_uptime[i["instanceArn"].split("/")[1]],
         }
         for i in response["instanceRecommendations"]
     ]
 
     return recs
+
+
+def describe_instances_uptime(config: Dict[str, Any]) -> Dict[str, str]:
+    """List EC2 instance uptimes in the region."""
+
+    ec2_client = boto3.client("ec2", region_name=config["region"])
+
+    response = ec2_client.describe_instances()
+
+    instances = {
+        i["InstanceId"]: difference_in_words(datetime.now(pytz.utc), i["LaunchTime"])
+        for r in response["Reservations"]
+        for i in r["Instances"]
+    }
+
+    return instances
+
+
+def difference_in_words(date1: datetime, date2: datetime) -> str:
+    difference = relativedelta.relativedelta(date1, date2)
+
+    words = ""
+
+    if difference.months > 0:
+        words += f"{difference.months} months "
+    if difference.days > 0:
+        words += f"{difference.days} days "
+    if difference.hours > 0:
+        words += f"{difference.hours} hours "
+    if words == "":
+        if difference.minutes != 0:
+            words = f"{difference.minutes} minutes"
+        else:
+            words = f"{difference.seconds} seconds"
+
+    return words
+

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -18,10 +18,10 @@ To show recommendations for over-provisioned instances (eg: idle instances runni
 ```
 $ aec co over-provisioned
 
-  ID                    Name         Instance Type   Recommendation   Utilization
- ─────────────────────────────────────────────────────────────────────────────────
-  i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0
-  i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0
-  i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 4.0
+  ID                    Name         Instance Type   Recommendation   Utilization    Uptime
+ ─────────────────────────────────────────────────────────────────────────────────────────────────────
+  i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0    7 days 8 hours
+  i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0   7 days 8 hours
+  i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 30.0   23 days 8 hours
 
 ```


### PR DESCRIPTION
```
$ aec co over-provisioned

  ID                    Name         Instance Type   Recommendation   Utilization    Uptime
 ─────────────────────────────────────────────────────────────────────────────────────────────────────
  i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0    7 days 8 hours
  i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0   7 days 8 hours
  i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 30.0   23 days 8 hours

```