### PR TITLE
fix: No module named 'pytz'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto3-stubs[ec2,sqs,compute-optimizer,ssm]==1.14.46.0
 pyjq==2.4.0
 pytoml==0.1.21
+pytz==2020.1
 rich==5.2.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.4.6",
+    version="0.4.7",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_compute_optimizer.py
+++ b/tests/test_compute_optimizer.py
@@ -1,0 +1,42 @@
+import boto3
+import pytest
+from moto import mock_ec2
+from moto.ec2 import ec2_backends
+from moto.ec2.models import AMIS
+
+from aec.command.ec2 import (
+    delete_image,
+    describe,
+    describe_images,
+    launch,
+    logs,
+    modify,
+    share_image,
+    start,
+    stop,
+    terminate,
+)
+
+from aec.command.compute_optimizer import describe_instances_uptime
+
+@pytest.fixture
+def mock_aws_config():
+    mock = mock_ec2()
+    mock.start()
+    region = "ap-southeast-2"
+
+    return {
+        "region": region,
+        "additional_tags": {"Owner": "alice@testlab.io", "Project": "test project a"},
+        "key_name": "test_key",
+        "vpc": {
+            "name": "test vpc",
+            "subnet": next(ec2_backends[region].get_all_subnets()).id,
+            "security_group": "default",
+        },
+        "iam_instance_profile_arn": "test_profile",
+    }
+
+def test_describe_instances_uptime(mock_aws_config):
+    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    describe_instances_uptime(mock_aws_config)

--- a/tests/test_compute_optimizer.py
+++ b/tests/test_compute_optimizer.py
@@ -1,23 +1,16 @@
-import boto3
+
 import pytest
 from moto import mock_ec2
 from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
+from aec.command.compute_optimizer import describe_instances_uptime
 from aec.command.ec2 import (
-    delete_image,
-    describe,
-    describe_images,
+
     launch,
-    logs,
-    modify,
-    share_image,
-    start,
-    stop,
-    terminate,
+ 
 )
 
-from aec.command.compute_optimizer import describe_instances_uptime
 
 @pytest.fixture
 def mock_aws_config():
@@ -36,6 +29,7 @@ def mock_aws_config():
         },
         "iam_instance_profile_arn": "test_profile",
     }
+
 
 def test_describe_instances_uptime(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])

--- a/tests/test_compute_optimizer.py
+++ b/tests/test_compute_optimizer.py
@@ -1,15 +1,10 @@
-
 import pytest
 from moto import mock_ec2
 from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
 from aec.command.compute_optimizer import describe_instances_uptime
-from aec.command.ec2 import (
-
-    launch,
- 
-)
+from aec.command.ec2 import launch
 
 
 @pytest.fixture


### PR DESCRIPTION
pytz is included as a transitive dev dependency, but was missing from the application deps

bump 0.4.7 