### PR TITLE
change: ec2 describe - name is a positional arg

### DIFF
--- a/aec/main.py
+++ b/aec/main.py
@@ -27,7 +27,7 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("--name", type=str, help="Filter to hosts with this Name tag")
+        Arg("name", type=str, nargs='?', help="Filter to hosts with this Name tag")
     ]),
     Cmd(ec2.describe_images, [
         config_arg,


### PR DESCRIPTION
Change from
```
aec ec2 describe --name my-awesome-instance
```
to
```
aec ec2 describe my-awesome-instance
```

This makes ec2 describe consistent with all other commands that take name as a positional argument. 