### PR TITLE
feat: ec2 describe -q

### DIFF
--- a/aec/command/ec2.py
+++ b/aec/command/ec2.py
@@ -160,7 +160,7 @@ def launch(
     return describe(config=config, name=name)
 
 
-def describe(config: Dict[str, Any], name: Optional[str] = None) -> List[Dict[str, Any]]:
+def describe(config: Dict[str, Any], name: Optional[str] = None, name_contains: Optional[str] = None) -> List[Dict[str, Any]]:
     """List EC2 instances in the region."""
 
     ec2_client = boto3.client("ec2", region_name=config["region"])
@@ -183,6 +183,9 @@ def describe(config: Dict[str, Any], name: Optional[str] = None) -> List[Dict[st
         for r in response["Reservations"]
         for i in r["Instances"]
     ]
+
+    if name_contains:
+        instances = [i for i in instances if i["Name"] and name_contains in i["Name"]]
 
     return sorted(instances, key=lambda i: i["State"] + str(i["Name"]))
 

--- a/aec/command/ec2.py
+++ b/aec/command/ec2.py
@@ -172,7 +172,7 @@ def describe(
 
     # print(response["Reservations"][0]["Instances"][0])
 
-    instances = [
+    instances: List[Dict[str, Any]] = [
         {
             "State": i["State"]["Name"],
             "Name": first_or_else([t["Value"] for t in i.get("Tags", []) if t["Key"] == "Name"], None),

--- a/aec/command/ec2.py
+++ b/aec/command/ec2.py
@@ -160,7 +160,9 @@ def launch(
     return describe(config=config, name=name)
 
 
-def describe(config: Dict[str, Any], name: Optional[str] = None, name_contains: Optional[str] = None) -> List[Dict[str, Any]]:
+def describe(
+    config: Dict[str, Any], name: Optional[str] = None, name_contains: Optional[str] = None
+) -> List[Dict[str, Any]]:
     """List EC2 instances in the region."""
 
     ec2_client = boto3.client("ec2", region_name=config["region"])

--- a/aec/main.py
+++ b/aec/main.py
@@ -27,7 +27,8 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to hosts with this Name tag")
+        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag"),
+        Arg("-q", type=str, help="Filter to instances with a Name tag containing Q")
     ]),
     Cmd(ec2.describe_images, [
         config_arg,

--- a/aec/main.py
+++ b/aec/main.py
@@ -28,7 +28,7 @@ ec2_cli = [
     Cmd(ec2.describe, [
         config_arg,
         Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag"),
-        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing Q")
+        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS")
     ]),
     Cmd(ec2.describe_images, [
         config_arg,

--- a/aec/main.py
+++ b/aec/main.py
@@ -28,7 +28,7 @@ ec2_cli = [
     Cmd(ec2.describe, [
         config_arg,
         Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag"),
-        Arg("-q", type=str, help="Filter to instances with a Name tag containing Q")
+        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing Q")
     ]),
     Cmd(ec2.describe_images, [
         config_arg,

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -111,6 +111,7 @@ def test_describe_by_name(mock_aws_config):
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
 
+
 def test_describe_by_name_contains(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
 
@@ -119,6 +120,7 @@ def test_describe_by_name_contains(mock_aws_config):
 
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
+
 
 def describe_instance0(region_name, instance_id):
     ec2_client = boto3.client("ec2", region_name=region_name)

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -111,6 +111,14 @@ def test_describe_by_name(mock_aws_config):
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
 
+def test_describe_by_name_contains(mock_aws_config):
+    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+
+    instances = describe(config=mock_aws_config, name_contains="lic")
+    print(instances)
+
+    assert len(instances) == 1
+    assert instances[0]["Name"] == "alice"
 
 def describe_instance0(region_name, instance_id):
     ec2_client = boto3.client("ec2", region_name=region_name)


### PR DESCRIPTION
ec2 describe now adds:
```
  -q NAME_CONTAINS  Filter to instances with a Name tag containing NAME_CONTAINS (default:
                    None)
```