### PR TITLE
Fix failing build

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
+      id: setup-python
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
@@ -17,7 +18,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.virtualenvs
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements.*') }}
+        key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('**/requirements.*') }}
     - uses: pre-commit/action@v2.0.0
       with:
         extra_args: --all-files --hook-stage push

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: end-of-file-fixer
         stages: [push]
   - repo: https://github.com/ambv/black
-    rev: stable
+    rev: 19.10b0
     hooks:
       - id: black
   - repo: https://github.com/timothycrosley/isort


### PR DESCRIPTION
actions/setup-python@v1 bumped the python version to 3.7.9. When this happen the python binary in the cached virtualenv is [borked](https://github.com/seek-oss/aec/runs/1066085039?check_suite_focus=true#step:5:95):
```
~/.virtualenvs/aec/bin/pip install -e '.[dev]'
/bin/bash: /home/runner/.virtualenvs/aec/bin/pip: /home/runner/.virtualenvs/aec/bin/python3: bad interpreter: No such file or directory
Makefile:20: recipe for target '/home/runner/.virtualenvs/aec' failed
```
I've fixed this by using the python version in the cache key to bust the cache.

Also, for some unknown reason, the latest stable version of black (20.8b1) introduces [new formatting changes](https://github.com/seek-oss/aec/runs/1066085039?check_suite_focus=true#step:5:116), so I've pinned it to the old version for now. 