### PR TITLE
move requirements into setup.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
     hooks:
-      - id: requirements-txt-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
         stages: [push]

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(pip):
 	$(if $(value VIRTUAL_ENV),$(error Cannot create a virtualenv when running in a virtualenv. Please deactivate the current virtual env $(VIRTUAL_ENV)),)
 	python3 -m venv --clear $(venv)
 
-$(venv): requirements.* setup.py $(pip)
+$(venv): setup.py $(pip)
 	$(pip) install -e '.[dev]'
 	touch $(venv)
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,0 @@
-black==19.10b0
-flake8==3.8.3
-moto==1.3.14
-pre-commit==2.6.0
-pytest==6.0.1
-tox==3.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-boto3-stubs[ec2,sqs,compute-optimizer,ssm]==1.14.52.1
-pyjq==2.4.0
-pytoml==0.1.21
-pytz==2020.1
-rich==5.2.1

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,6 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-install_requires = Path("requirements.txt").read_text()
-extras_dev = Path("requirements.dev.txt").read_text()
-
 long_description = Path("README.md").read_text()
 
 setup(
@@ -19,6 +16,14 @@ setup(
     python_requires=">=3.7",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=install_requires,
-    extras_require={"dev": extras_dev},
+    install_requires=[
+        "boto3-stubs[ec2,sqs,compute-optimizer,ssm]==1.14.52.1",
+        "pyjq==2.4.0",
+        "pytoml==0.1.21",
+        "pytz==2020.1",
+        "rich==5.2.1",
+    ],
+    extras_require={
+        "dev": ["black==19.10b0", "flake8==3.8.3", "moto==1.3.14", "pre-commit==2.6.0", "pytest==6.0.1", "tox==3.19.0"]
+    },
 )


### PR DESCRIPTION
since we use `pip install -e .[dev]` rather than `pip install -r requirements.txt` in the Makefile, we don't really need the requirements.txt files.  