### PR TITLE
bust cache based on setup.py

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.virtualenvs
-        key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('**/requirements.*') }}
+        key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('setup.py') }}
     - uses: pre-commit/action@v2.0.0
       with:
         extra_args: --all-files --hook-stage push


### PR DESCRIPTION
https://github.com/seek-oss/aec/pull/188 removed requirements.txt but the github actions cache uses requirements.* to bust the cache. This PR updates the action to use setup.py instead.


fix broken builds for https://github.com/seek-oss/aec/pull/190 and https://github.com/seek-oss/aec/pull/192