### PR TITLE
fix: install wheel into venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ $(pip):
 	# create empty virtualenv containing pip
 	$(if $(value VIRTUAL_ENV),$(error Cannot create a virtualenv when running in a virtualenv. Please deactivate the current virtual env $(VIRTUAL_ENV)),)
 	python3 -m venv --clear $(venv)
+	$(pip) install wheel
 
 $(venv): setup.py $(pip)
 	$(pip) install -e '.[dev]'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently supports the following AWS services:
 ## Prerequisites
 
 - python 3.7+
-- pip3
+  - Ubuntu: `sudo apt install python3 python3-pip python3-dev python3-venv`
 - automake & libtool:
   - Ubuntu: `sudo apt install automake libtool`
   - macOS: `brew install automake libtool`


### PR DESCRIPTION
On a clean install (ie: empty *~/.cache/pip/wheels/*) wheels will need to be built. In this scenario `make install` errors with:
```
  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for pyjq
```

Because the virtualenv created by `venv` does not install `wheel` [by design](https://bugs.python.org/issue30628#msg295844):
> It should also be noted that wheel is not installed by venv and must also be installed after the environment creation if needed.

This PR fixes this.