### PR TITLE
refactor: use ./venv/ for virtual environment

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,6 @@
 [flake8]
 max-line-length=120
-exclude =
-    .git,
-    __pycache__,
-    dist,
-    docs
+exclude = .git,__pycache__,node_modules,typings,.tox,build,dist,venv
 
 ignore =
     # The following are ignored because they will be fixed by black/isort
@@ -12,10 +8,14 @@ ignore =
     # allow untyped self and cls args, and no return type from dunder methods
     ANN101, ANN102, ANN204
 
+# test functions don't need type annotations
+per-file-ignores = tests/*:ANN001,ANN201
+
 # flake8-colors
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
 
 max-complexity = 10
 
-# test functions don't need type annotations
-per-file-ignores = tests/*:ANN001,ANN201
+
+statistics = True
+count = True

--- a/.flake8
+++ b/.flake8
@@ -16,6 +16,6 @@ format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(co
 
 max-complexity = 10
 
-
+# print stats & count
 statistics = True
 count = True

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,8 +17,11 @@ jobs:
     - name: Cache virtualenv
       uses: actions/cache@v2
       with:
-        path: ~/.virtualenvs
+        path: venv
         key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('setup.py') }}
+    - name: install
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: make install
     - uses: pre-commit/action@v2.0.0
       with:
         extra_args: --all-files --hook-stage push

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ typings/
 .tox/
 pip-wheel-metadata/
 node_modules/
+venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,14 @@ repos:
         stages: [push]
       - id: end-of-file-fixer
         stages: [push]
-  - repo: https://github.com/ambv/black
-    rev: 20.8b1
+  # we want vscode/the cli to use black too so it has been installed into the virtualenv
+  - repo: local
     hooks:
       - id: black
+        name: black
+        entry: venv/bin/black
+        language: system
+        types: [python]
   - repo: https://github.com/timothycrosley/isort
     rev: 5.4.2
     hooks:
@@ -22,20 +26,15 @@ repos:
     hooks:
       - id: docformatter
         args: [--wrap-summaries,'120',--wrap-descriptions,'120',--pre-summary-newline,--in-place]
-  - repo: https://github.com/terrencepreilly/darglint
-    rev: v1.5.4
-    hooks:
-      - id: darglint
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+  # we want vscode/the cli to use flake8 too so it has been installed into the virtualenv
+  - repo: local
     hooks:
       - id: flake8
-        additional_dependencies: [
-            'flake8-colors==0.1.6',
-            'flake8-annotations==2.3.0'
-        ]
-        args: [--statistics,--count]
-  # these hooks require the project's virtualenv so need to be local and language: system
+        name: flake8
+        entry: venv/bin/flake8
+        language: system
+        types: [python]
+  # these hooks require the project's virtualenv and need to run on all files
   - repo: local
     hooks:
       - id: pyright

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
         stages: [push]
       - id: end-of-file-fixer
         stages: [push]
-  # we want vscode/the cli to use black too so it has been installed into the virtualenv
+  # vscode/the cli uses black too so it has been installed into the virtualenv
   - repo: local
     hooks:
       - id: black
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: docformatter
         args: [--wrap-summaries,'120',--wrap-descriptions,'120',--pre-summary-newline,--in-place]
-  # we want vscode/the cli to use flake8 too so it has been installed into the virtualenv
+  # vscode/the cli uses flake8 too so it has been installed into the virtualenv
   - repo: local
     hooks:
       - id: flake8

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL = /bin/bash -o pipefail
 help:
 	@awk '/^##.*$$/,/^[~\/\.0-9a-zA-Z_-]+:/' $(MAKEFILE_LIST) | awk '!(NR%2){print $$0p}{p=$$0}' | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort
 
-venv = ~/.virtualenvs/aec
+venv = venv
 pip := $(venv)/bin/pip
 src := aec tests
 
@@ -31,11 +31,11 @@ typings: $(venv)
 install: $(venv) typings $(if $(value CI),,install-hooks)
 
 ## lint code and run static type check
-check: lint pyright
+check: flake8 pyright
 
-## lint
-lint: install-hooks
-	$(venv)/bin/pre-commit run --all-files --hook-stage push flake8
+## lint using flake8
+flake8: $(venv)
+	$(venv)/bin/flake8
 
 node_modules: package.json
 	npm install

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             "darglint==1.5.4",
             "flake8==3.8.3",
             "flake8-annotations==2.3.0",
+            "flake8-colors==0.1.6",
             "moto==1.3.14",
             "pre-commit==2.7.1",
             "pytest==6.0.1",


### PR DESCRIPTION
use _./venv/_ for the virtual environment so it can be referenced from the pre-commit hooks. This means flake8 and black only need to be installed in one place (the virtualenv) for use by pre-commit and vscode.

Another advantage is dependabot will automatically keep them up to date.

darglint integrates with flake8, so it doesn't need to be run separately from flake8. 