### PR TITLE
by default don't show terminated instances

### DIFF
--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -162,7 +162,10 @@ def launch(
 
 
 def describe(
-    config: Dict[str, Any], name: Optional[str] = None, name_contains: Optional[str] = None
+    config: Dict[str, Any],
+    name: Optional[str] = None,
+    name_contains: Optional[str] = None,
+    include_terminated: bool = False,
 ) -> List[Dict[str, Any]]:
     """List EC2 instances in the region."""
 
@@ -185,6 +188,7 @@ def describe(
         }
         for r in response["Reservations"]
         for i in r["Instances"]
+        if include_terminated or i["State"]["Name"] != "terminated"
     ]
 
     if name_contains:

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -28,7 +28,8 @@ ec2_cli = [
     Cmd(ec2.describe, [
         config_arg,
         Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag"),
-        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS")
+        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS"),
+        Arg("-it", "--include-terminated", action='store_true', dest='name_contains', help="Include terminated instances"),
     ]),
     Cmd(ec2.describe_images, [
         config_arg,

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -131,6 +131,21 @@ def test_describe_by_name_contains(mock_aws_config):
     assert instances[0]["Name"] == "alice"
 
 
+def test_describe_terminated(mock_aws_config):
+    launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    launch(mock_aws_config, "sam", AMIS[0]["ami_id"])
+    terminate(mock_aws_config, "sam")
+
+    # by default don't show terminated instances
+    instances = describe(config=mock_aws_config)
+    assert len(instances) == 1
+    assert instances[0]["Name"] == "alice"
+
+    # when requested, show terminated instances
+    instances = describe(config=mock_aws_config, include_terminated=True)
+    assert len(instances) == 2
+
+
 def describe_instance0(region_name, instance_id):
     ec2_client = boto3.client("ec2", region_name=region_name)
     instances = ec2_client.describe_instances(InstanceIds=[instance_id])


### PR DESCRIPTION
because it's not very useful. In particular, for the case where the terminated instance has the same name as a running instance, the start/stop/modify etc. commands will fail because they try to operate on the terminated instance.