### PR TITLE
feat: describe images name match

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ To get started, run `aec configure example` to install the [example config files
 For even faster access to aec subcommands, you may like to add the following aliases to your .bashrc:
 
 ```
-alias ec2='aec ec2'
-alias sqs='aec sqs'
+alias ec2='COLUMNS=$COLUMNS aec ec2'
+alias sqs='COLUMNS=$COLUMNS aec sqs'
 ```
+
+`COLUMNS=$COLUMNS` will ensure output is formatted to the width of your terminal when piped.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ aggressive = 1
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
-skip = [ ".tox", "dist", "node_modules" , "venv", "build", ".git"]
+skip = [ ".tox", "dist", "node_modules" , "venv", "build", ".git", "typings"]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.4.8",
+    version="0.4.9",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -38,7 +38,7 @@ def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
 def describe_images(
     config: Dict[str, Any],
     ami: Optional[str] = None,
-    name_contains: Optional[str] = None,
+    name_match: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """List AMIs."""
 
@@ -56,12 +56,10 @@ def describe_images(
         else:
             owners: List[str] = describe_images_owners
 
-        if name_contains is None:
-            name_contains = config.get("describe_images_name_contains", None)
+        if name_match is None:
+            name_match = config.get("describe_images_name_match", None)
 
-        filters: List[FilterTypeDef] = (
-            [] if name_contains is None else [{"Name": "name", "Values": [f"*{name_contains}*"]}]
-        )
+        filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
 
         response = ec2_client.describe_images(Owners=owners, Filters=filters)
 
@@ -175,7 +173,7 @@ def launch(
 def describe(
     config: Dict[str, Any],
     name: Optional[str] = None,
-    name_contains: Optional[str] = None,
+    name_match: Optional[str] = None,
     include_terminated: bool = False,
 ) -> List[Dict[str, Any]]:
     """List EC2 instances in the region."""
@@ -185,8 +183,8 @@ def describe(
     filters: List[FilterTypeDef] = []
     if name:
         filters = [{"Name": "tag:Name", "Values": [name]}]
-    elif name_contains:
-        filters = [{"Name": "tag:Name", "Values": [f"*{name_contains}*"]}]
+    elif name_match:
+        filters = [{"Name": "tag:Name", "Values": [f"*{name_match}*"]}]
 
     response = ec2_client.describe_instances(Filters=filters)
 

--- a/src/aec/config-example/ec2.toml
+++ b/src/aec/config-example/ec2.toml
@@ -22,6 +22,7 @@ vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0
 
 # include these accounts when listing AMIs
 describe_images_owners = [ "self", "123456789012"]
+describe_images_name_contains = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
 
 [no-region]
 # no region specified so will default to $AWS_DEFAULT_REGION, and then ~/.aws/config

--- a/src/aec/config-example/ec2.toml
+++ b/src/aec/config-example/ec2.toml
@@ -22,7 +22,7 @@ vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0
 
 # include these accounts when listing AMIs
 describe_images_owners = [ "self", "123456789012"]
-describe_images_name_contains = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
+describe_images_name_match = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
 
 [no-region]
 # no region specified so will default to $AWS_DEFAULT_REGION, and then ~/.aws/config

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -27,14 +27,14 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances matching this Name tag."),
-        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS."),
-        Arg("-it", "--include-terminated", action='store_true', dest='name_contains', help="Include terminated instances"),
+        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag."),
+        Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
+        Arg("-it", "--include-terminated", action='store_true', dest='name_match', help="Include terminated instances"),
     ]),
     Cmd(ec2.describe_images, [
         config_arg,
         Arg("--ami", type=str, help="Filter to this AMI id"),
-        Arg("-q", type=str, dest='name_contains', help="Filter to images with a name containing NAME_CONTAINS."),
+        Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
     ]),
     Cmd(ec2.launch, [
         config_arg,

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -27,13 +27,14 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag"),
-        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS"),
+        Arg("name", type=str, nargs='?', help="Filter to instances matching this Name tag."),
+        Arg("-q", type=str, dest='name_contains', help="Filter to instances with a Name tag containing NAME_CONTAINS."),
         Arg("-it", "--include-terminated", action='store_true', dest='name_contains', help="Include terminated instances"),
     ]),
     Cmd(ec2.describe_images, [
         config_arg,
-        Arg("--ami", type=str, help="Filter to this AMI id")
+        Arg("--ami", type=str, help="Filter to this AMI id"),
+        Arg("-q", type=str, dest='name_contains', help="Filter to images with a name containing NAME_CONTAINS."),
     ]),
     Cmd(ec2.launch, [
         config_arg,

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -121,10 +121,10 @@ def test_describe_by_name(mock_aws_config):
     assert instances[0]["Name"] == "alice"
 
 
-def test_describe_by_name_contains(mock_aws_config):
+def test_describe_by_name_match(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
 
-    instances = describe(config=mock_aws_config, name_contains="lic")
+    instances = describe(config=mock_aws_config, name_match="lic")
     print(instances)
 
     assert len(instances) == 1
@@ -164,12 +164,12 @@ def test_describe_images(mock_aws_config):
     assert images[1]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"
 
 
-def test_describe_images_name_contains(mock_aws_config):
+def test_describe_images_name_match(mock_aws_config):
     # describe images defined by moto
     # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
     canonical_account_id = "099720109477"
     mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe_images(config=mock_aws_config, name_contains="*trusty*")
+    images = describe_images(config=mock_aws_config, name_match="*trusty*")
 
     assert len(images) == 1
     assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -161,6 +161,18 @@ def test_describe_images(mock_aws_config):
 
     assert len(images) == 2
     assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
+    assert images[1]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"
+
+
+def test_describe_images_name_contains(mock_aws_config):
+    # describe images defined by moto
+    # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
+    canonical_account_id = "099720109477"
+    mock_aws_config["describe_images_owners"] = canonical_account_id
+    images = describe_images(config=mock_aws_config, name_contains="*trusty*")
+
+    assert len(images) == 1
+    assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
 
 
 def test_stop_start(mock_aws_config):


### PR DESCRIPTION
Describe images with a matching name, eg: to describe ubuntu focal images:

```
aec ec2 describe-images -q ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64
```

There is also a new config option `describe_images_name_match`