### PR TITLE
feat: select latest ami based on keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.4.9",
+    version="0.4.10",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -89,10 +89,10 @@ class AmiMatcher(NamedTuple):
     match_string: str
 
 
-canonical_account_id = "099720109477"
 amazon_base_account_id = "137112412989"
+canonical_account_id = "099720109477"
 
-ami_matchers = {
+ami_keywords = {
     "amazon2": AmiMatcher("amazon", amazon_base_account_id, "amzn2-ami-hvm*x86_64-gp2"),
     "ubuntu1604": AmiMatcher("ubuntu", canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64"),
     "ubuntu1804": AmiMatcher("ubuntu", canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64"),
@@ -111,7 +111,11 @@ def launch(
     key_name: Optional[str] = None,
     userdata: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Launch a tagged EC2 instance with an EBS volume."""
+    """
+    Launch a tagged EC2 instance with an EBS volume.
+
+    Specify an AMI keyword to select the latest AMI for that distro and version.
+    """
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -123,7 +127,7 @@ def launch(
     if not key_name:
         key_name = config["key_name"]
 
-    ami_matcher = ami_matchers.get(ami, None)
+    ami_matcher = ami_keywords.get(ami, None)
     if ami_matcher:
         dist = ami_matcher.dist
         try:

--- a/src/aec/config-example/ec2.toml
+++ b/src/aec/config-example/ec2.toml
@@ -20,8 +20,9 @@ key_name = "my-key-us"
 iam_instance_profile_arn = "arn:aws:iam::123456789012:instance-profile/ec2_my_default"
 vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0123456","sg-7123456789"], associate_public_ip_address = true }
 
-# include these accounts when listing AMIs
-describe_images_owners = [ "self", "123456789012"]
+# include my account and the Canonical (Ubuntu) account when listing AMIs
+describe_images_owners = ["self", "099720109477"]
+# show the ubuntu focal images
 describe_images_name_match = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
 
 [no-region]

--- a/src/aec/config-example/ec2.toml
+++ b/src/aec/config-example/ec2.toml
@@ -22,7 +22,7 @@ vpc = { name = "private B", subnet = "subnet-87654321",  security_group = ["sg-0
 
 # include my account and the Canonical (Ubuntu) account when listing AMIs
 describe_images_owners = ["self", "099720109477"]
-# show the ubuntu focal images
+# show only the ubuntu focal images
 describe_images_name_match = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
 
 [no-region]

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -14,6 +14,13 @@ from aec.util.cli import Arg, Cmd
 
 config_arg = Arg("--config", help="Section of the config file to use")
 
+
+def ami_arg_checker(s: str) -> str:
+    if not (s.startswith("ami-") or s in ec2.ami_matchers.keys()):
+        raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {[k for k in ec2.ami_matchers.keys()]}")
+    return s
+
+
 # fmt: off
 
 configure_cli = [
@@ -34,12 +41,13 @@ ec2_cli = [
     Cmd(ec2.describe_images, [
         config_arg,
         Arg("--ami", type=str, help="Filter to this AMI id"),
+        Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
     ]),
     Cmd(ec2.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
-        Arg("ami", type=str, help="AMI id"),
+        Arg("ami", type=ami_arg_checker, help=f"AMI id or one of {[k for k in ec2.ami_matchers.keys()]}"),
         Arg("--dist", type=str, help="Linux distribution", choices=ec2.root_devices.keys(), default="amazon"),
         Arg("--volume-size", type=int, help="EBS volume size (GB)", default=100),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -16,8 +16,8 @@ config_arg = Arg("--config", help="Section of the config file to use")
 
 
 def ami_arg_checker(s: str) -> str:
-    if not (s.startswith("ami-") or s in ec2.ami_matchers.keys()):
-        raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {[k for k in ec2.ami_matchers.keys()]}")
+    if not (s.startswith("ami-") or s in ec2.ami_keywords.keys()):
+        raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {[k for k in ec2.ami_keywords.keys()]}")
     return s
 
 
@@ -47,7 +47,7 @@ ec2_cli = [
     Cmd(ec2.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
-        Arg("ami", type=ami_arg_checker, help=f"AMI id or one of {[k for k in ec2.ami_matchers.keys()]}"),
+        Arg("ami", type=ami_arg_checker, help=f"AMI id or a one of the keywords {[k for k in ec2.ami_keywords.keys()]}"),
         Arg("--dist", type=str, help="Linux distribution", choices=ec2.root_devices.keys(), default="amazon"),
         Arg("--volume-size", type=int, help="EBS volume size (GB)", default=100),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -61,11 +61,16 @@ def test_launch_no_region_specified(mock_aws_config):
     assert "amazonaws.com" in instances[0]["DnsName"]
 
 
-@pytest.mark.skip(reason="failing because of https://github.com/spulec/moto/pull/2651")
+@pytest.mark.skip(reason="failing because of https://github.com/spulec/moto/issues/2762")
 def test_launch_without_public_ip_address(mock_aws_config):
     mock_aws_config["vpc"]["associate_public_ip_address"] = False
     instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
     assert "ec2.internal" in instances[0]["DnsName"]
+
+
+def test_launch_with_ami_match_string(mock_aws_config):
+    instances = launch(mock_aws_config, "alice", "ubuntu1604")
+    assert "amazonaws.com" in instances[0]["DnsName"]
 
 
 def test_override_key_name(mock_aws_config):


### PR DESCRIPTION
`ec2 launch` now also takes an ami keyword:

```
usage: aec ec2 launch [-h] [--config CONFIG] [--dist {amazon,ubuntu}] [--volume-size VOLUME_SIZE] [--encrypted ENCRYPTED]
                      [--instance-type INSTANCE_TYPE] [--key-name KEY_NAME] [--userdata USERDATA]
                      name ami

Launch a tagged EC2 instance with an EBS volume. Specify an AMI keyword to select the latest AMI for that distro and version.

positional arguments:
  name                  Name tag of instance
  ami                   AMI id or a one of the keywords ['amazon2', 'ubuntu1604', 'ubuntu1804', 'ubuntu2004']
```

Based on the keyword, it will select the latest version of the relevant distro's x86_64 SSD AMI. This saves the user from having to look up the ami id each time.