### PR TITLE
feat: remove dist arg and lookup root device from the ami

### DIFF
--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -30,10 +30,10 @@ To list AMIs (owned by accounts specified in the config file)
 aec ec2 describe-images
 ```
 
-To launch a t2.medium instance named `lady gaga` with a 100gb EBS volume, with other settings read from the config file
+To launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file
 
 ```
-aec ec2 launch "lady gaga" ami-0bfe6b818fce462af --instance-type t2.medium --volume-size 100
+aec ec2 launch "lady gaga" ubuntu1804 --instance-type t2.medium --volume-size 50
 ```
 
 Stop the instance

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.4.10",
+    version="0.5.0",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "pyjq==2.4.0",
         "pytoml==0.1.21",
         "pytz==2020.1",
-        "rich==8.0.0",
+        "rich==9.1.0",
     ],
     extras_require={
         "dev": [

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -4,7 +4,6 @@ from typing import Any, AnyStr, Dict, List, NamedTuple, Optional
 
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
-from rich import print
 from typing_extensions import TypedDict
 
 from aec.util.list import first_or_else
@@ -76,7 +75,7 @@ def describe_images(
         filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
 
         print(
-            f"Describing images owned by {owners_filter} with name matching [not bold green]{name_match if name_match else '*'}[/not bold green]"
+            f"Describing images owned by {owners_filter} with name matching {name_match if name_match else '*'}"
         )
         response = ec2_client.describe_images(Owners=owners_filter, Filters=filters)
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -4,6 +4,8 @@ from typing import Any, AnyStr, Dict, List, NamedTuple, Optional
 
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
+from rich import print
+from typing_extensions import TypedDict
 
 from aec.util.list import first_or_else
 
@@ -13,7 +15,7 @@ def delete_image(config: Dict[str, Any], ami: str) -> None:
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
-    response = describe_images(config, ami)
+    response = describe_images(config, ami, show_snapshot_id=True)
 
     ec2_client.deregister_image(ImageId=ami)
 
@@ -35,12 +37,20 @@ def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
     )
 
 
+Image = TypedDict(
+    "Image",
+    {"Name": Optional[str], "ImageId": str, "CreationDate": str, "RootDeviceName": str, "SnapshotId": str},
+    total=False,
+)
+
+
 def describe_images(
     config: Dict[str, Any],
     ami: Optional[str] = None,
     owner: Optional[str] = None,
     name_match: Optional[str] = None,
-) -> List[Dict[str, Any]]:
+    show_snapshot_id: bool = False,
+) -> List[Image]:
     """List AMIs."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
@@ -65,26 +75,37 @@ def describe_images(
 
         filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
 
+        print(
+            f"Describing images owned by {owners_filter} with name matching [not bold green]{name_match if name_match else '*'}[/not bold green]"
+        )
         response = ec2_client.describe_images(Owners=owners_filter, Filters=filters)
 
-    images = [
+    images: List[Image] = [
         {
             "Name": i.get("Name", None),
             "ImageId": i["ImageId"],
             "CreationDate": i["CreationDate"],
-            "SnapshotId": i["BlockDeviceMappings"][0]["Ebs"]["SnapshotId"] if i["BlockDeviceMappings"] else None,
+            "RootDeviceName": i["RootDeviceName"],
         }
         for i in response["Images"]
     ]
 
+    images = []
+    for i in response["Images"]:
+        image: Image = {
+            "Name": i.get("Name", None),
+            "ImageId": i["ImageId"],
+            "CreationDate": i["CreationDate"],
+            "RootDeviceName": i["RootDeviceName"],
+        }
+        if show_snapshot_id:
+            image["SnapshotId"] = i["BlockDeviceMappings"][0]["Ebs"]["SnapshotId"]
+        images.append(image)
+
     return sorted(images, key=lambda i: i["CreationDate"], reverse=True)
 
 
-root_devices = {"amazon": "/dev/xvda", "ubuntu": "/dev/sda1"}
-
-
 class AmiMatcher(NamedTuple):
-    dist: str
     owner: str
     match_string: str
 
@@ -93,10 +114,10 @@ amazon_base_account_id = "137112412989"
 canonical_account_id = "099720109477"
 
 ami_keywords = {
-    "amazon2": AmiMatcher("amazon", amazon_base_account_id, "amzn2-ami-hvm*x86_64-gp2"),
-    "ubuntu1604": AmiMatcher("ubuntu", canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64"),
-    "ubuntu1804": AmiMatcher("ubuntu", canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64"),
-    "ubuntu2004": AmiMatcher("ubuntu", canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"),
+    "amazon2": AmiMatcher(amazon_base_account_id, "amzn2-ami-hvm*x86_64-gp2"),
+    "ubuntu1604": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64"),
+    "ubuntu1804": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64"),
+    "ubuntu2004": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"),
 }
 
 
@@ -104,7 +125,6 @@ def launch(
     config: Dict[str, Any],
     name: str,
     ami: str,
-    dist: str = "amazon",
     volume_size: int = 100,
     encrypted: bool = True,
     instance_type: str = "t2.medium",
@@ -127,22 +147,11 @@ def launch(
     if not key_name:
         key_name = config["key_name"]
 
-    ami_matcher = ami_keywords.get(ami, None)
-    if ami_matcher:
-        dist = ami_matcher.dist
-        try:
-            # lookup the latest ami
-            ami = describe_images(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]["ImageId"]
-        except IndexError:
-            raise RuntimeError(
-                f"Could not find ami with name matching {ami_matcher.match_string} owned by account {ami_matcher.owner}"
-            )
-
-    root_device = root_devices[dist]
+    image = fetch_image(config, ami)
 
     # TODO: support multiple subnets
     kwargs: Dict[str, Any] = {
-        "ImageId": ami,
+        "ImageId": image["ImageId"],
         "MaxCount": 1,
         "MinCount": 1,
         "KeyName": key_name,
@@ -161,7 +170,7 @@ def launch(
         ],
         "BlockDeviceMappings": [
             {
-                "DeviceName": root_device,
+                "DeviceName": image["RootDeviceName"],
                 "Ebs": {
                     "VolumeSize": volume_size,
                     "DeleteOnTermination": True,
@@ -201,6 +210,25 @@ def launch(
     # the response from run_instances above always contains an empty string
     # for PublicDnsName, so we call describe to get it
     return describe(config=config, name=name)
+
+
+def fetch_image(config: Dict[str, Any], ami: str) -> Image:
+    ami_matcher = ami_keywords.get(ami, None)
+    if ami_matcher:
+        try:
+            # lookup the latest ami by name match
+            ami_details = describe_images(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]
+        except IndexError:
+            raise RuntimeError(
+                f"Could not find ami with name matching {ami_matcher.match_string} owned by account {ami_matcher.owner}"
+            )
+    else:
+        try:
+            # lookup by ami id
+            ami_details = describe_images(config, ami=ami)[0]
+        except IndexError:
+            raise RuntimeError(f"Could not find {ami}")
+    return ami_details
 
 
 def describe(

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -74,9 +74,7 @@ def describe_images(
 
         filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
 
-        print(
-            f"Describing images owned by {owners_filter} with name matching {name_match if name_match else '*'}"
-        )
+        print(f"Describing images owned by {owners_filter} with name matching {name_match if name_match else '*'}")
         response = ec2_client.describe_images(Owners=owners_filter, Filters=filters)
 
     images: List[Image] = [
@@ -196,7 +194,9 @@ def launch(
 
     region_name = ec2_client.meta.region_name
 
-    print(f"Launching a {instance_type} in {region_name} named {name} in " f"vpc {config['vpc']['name']}... ")
+    print(
+        f"Launching a {instance_type} in {region_name} vpc {config['vpc']['name']} named {name} using {image['Name']} ... "
+    )
     response = ec2_client.run_instances(**kwargs)
 
     instance = response["Instances"][0]

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -43,12 +43,12 @@ ec2_cli = [
         Arg("--ami", type=str, help="Filter to this AMI id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
+        Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
     ]),
     Cmd(ec2.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
         Arg("ami", type=ami_arg_checker, help=f"AMI id or a one of the keywords {[k for k in ec2.ami_keywords.keys()]}"),
-        Arg("--dist", type=str, help="Linux distribution", choices=ec2.root_devices.keys(), default="amazon"),
         Arg("--volume-size", type=int, help="EBS volume size (GB)", default=100),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),
         Arg("--instance-type", type=str, help="Instance type", default="t2.medium"),


### PR DESCRIPTION
Remove the `--dist` argument from `ec2 launch` and look up the correct root device name from the AMI rather than relying on the user to specify it.

I recently created an ubuntu instance and forgot to specify `--dist ubuntu`. This meant my EBS volume was never mounted.

This change makes this error impossible. 