### PR TITLE
refactor: split ec2 module into ec2_images & ec2_instances

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.5.0",
+    version="0.5.1",
     description="AWS Easy CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/aec/command/ec2_images.py
+++ b/src/aec/command/ec2_images.py
@@ -4,6 +4,12 @@ import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
 from typing_extensions import TypedDict
 
+Image = TypedDict(
+    "Image",
+    {"Name": Optional[str], "ImageId": str, "CreationDate": str, "RootDeviceName": str, "SnapshotId": str},
+    total=False,
+)
+
 
 def delete_image(config: Dict[str, Any], ami: str) -> None:
     """Deregister an AMI and delete its snapshot."""
@@ -30,13 +36,6 @@ def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
         Value="string",
         DryRun=False,
     )
-
-
-Image = TypedDict(
-    "Image",
-    {"Name": Optional[str], "ImageId": str, "CreationDate": str, "RootDeviceName": str, "SnapshotId": str},
-    total=False,
-)
 
 
 def describe_images(

--- a/src/aec/command/ec2_images.py
+++ b/src/aec/command/ec2_images.py
@@ -1,0 +1,133 @@
+from typing import Any, Dict, List, NamedTuple, Optional
+
+import boto3
+from mypy_boto3_ec2.type_defs import FilterTypeDef
+from typing_extensions import TypedDict
+
+
+def delete_image(config: Dict[str, Any], ami: str) -> None:
+    """Deregister an AMI and delete its snapshot."""
+
+    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
+
+    response = describe_images(config, ami, show_snapshot_id=True)
+
+    ec2_client.deregister_image(ImageId=ami)
+
+    ec2_client.delete_snapshot(SnapshotId=response[0]["SnapshotId"])
+
+
+def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
+    """Share an AMI with another account."""
+
+    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
+
+    ec2_client.modify_image_attribute(
+        ImageId=ami,
+        LaunchPermission={"Add": [{"UserId": account}]},
+        OperationType="add",
+        UserIds=[account],
+        Value="string",
+        DryRun=False,
+    )
+
+
+Image = TypedDict(
+    "Image",
+    {"Name": Optional[str], "ImageId": str, "CreationDate": str, "RootDeviceName": str, "SnapshotId": str},
+    total=False,
+)
+
+
+def describe_images(
+    config: Dict[str, Any],
+    ami: Optional[str] = None,
+    owner: Optional[str] = None,
+    name_match: Optional[str] = None,
+    show_snapshot_id: bool = False,
+) -> List[Image]:
+    """List AMIs."""
+
+    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
+
+    if ami:
+        response = ec2_client.describe_images(ImageIds=[ami])
+    else:
+        if owner:
+            owners_filter = [owner]
+        else:
+            describe_images_owners = config.get("describe_images_owners", None)
+
+            if not describe_images_owners:
+                owners_filter = ["self"]
+            elif isinstance(describe_images_owners, str):
+                owners_filter = [describe_images_owners]
+            else:
+                owners_filter: List[str] = describe_images_owners
+
+        if name_match is None:
+            name_match = config.get("describe_images_name_match", None)
+
+        filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
+
+        print(f"Describing images owned by {owners_filter} with name matching {name_match if name_match else '*'}")
+        response = ec2_client.describe_images(Owners=owners_filter, Filters=filters)
+
+    images: List[Image] = [
+        {
+            "Name": i.get("Name", None),
+            "ImageId": i["ImageId"],
+            "CreationDate": i["CreationDate"],
+            "RootDeviceName": i["RootDeviceName"],
+        }
+        for i in response["Images"]
+    ]
+
+    images = []
+    for i in response["Images"]:
+        image: Image = {
+            "Name": i.get("Name", None),
+            "ImageId": i["ImageId"],
+            "CreationDate": i["CreationDate"],
+            "RootDeviceName": i["RootDeviceName"],
+        }
+        if show_snapshot_id:
+            image["SnapshotId"] = i["BlockDeviceMappings"][0]["Ebs"]["SnapshotId"]
+        images.append(image)
+
+    return sorted(images, key=lambda i: i["CreationDate"], reverse=True)
+
+
+class AmiMatcher(NamedTuple):
+    owner: str
+    match_string: str
+
+
+amazon_base_account_id = "137112412989"
+canonical_account_id = "099720109477"
+
+ami_keywords = {
+    "amazon2": AmiMatcher(amazon_base_account_id, "amzn2-ami-hvm*x86_64-gp2"),
+    "ubuntu1604": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64"),
+    "ubuntu1804": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64"),
+    "ubuntu2004": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"),
+}
+
+
+def fetch_image(config: Dict[str, Any], ami: str) -> Image:
+    ami_matcher = ami_keywords.get(ami, None)
+    if ami_matcher:
+        try:
+            # lookup the latest ami by name match
+            ami_details = describe_images(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]
+        except IndexError:
+            raise RuntimeError(
+                f"Could not find ami with name matching {ami_matcher.match_string} owned by account {ami_matcher.owner}"
+            )
+    else:
+        try:
+            # lookup by ami id
+            ami_details = describe_images(config, ami=ami)[0]
+        except IndexError:
+            raise RuntimeError(f"Could not find {ami}")
+    return ami_details

--- a/src/aec/command/ec2_instances.py
+++ b/src/aec/command/ec2_instances.py
@@ -1,121 +1,12 @@
 import os
 import os.path
-from typing import Any, AnyStr, Dict, List, NamedTuple, Optional
+from typing import Any, AnyStr, Dict, List, Optional
 
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
-from typing_extensions import TypedDict
 
+from aec.command.ec2_images import fetch_image
 from aec.util.list import first_or_else
-
-
-def delete_image(config: Dict[str, Any], ami: str) -> None:
-    """Deregister an AMI and delete its snapshot."""
-
-    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
-
-    response = describe_images(config, ami, show_snapshot_id=True)
-
-    ec2_client.deregister_image(ImageId=ami)
-
-    ec2_client.delete_snapshot(SnapshotId=response[0]["SnapshotId"])
-
-
-def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
-    """Share an AMI with another account."""
-
-    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
-
-    ec2_client.modify_image_attribute(
-        ImageId=ami,
-        LaunchPermission={"Add": [{"UserId": account}]},
-        OperationType="add",
-        UserIds=[account],
-        Value="string",
-        DryRun=False,
-    )
-
-
-Image = TypedDict(
-    "Image",
-    {"Name": Optional[str], "ImageId": str, "CreationDate": str, "RootDeviceName": str, "SnapshotId": str},
-    total=False,
-)
-
-
-def describe_images(
-    config: Dict[str, Any],
-    ami: Optional[str] = None,
-    owner: Optional[str] = None,
-    name_match: Optional[str] = None,
-    show_snapshot_id: bool = False,
-) -> List[Image]:
-    """List AMIs."""
-
-    ec2_client = boto3.client("ec2", region_name=config.get("region", None))
-
-    if ami:
-        response = ec2_client.describe_images(ImageIds=[ami])
-    else:
-        if owner:
-            owners_filter = [owner]
-        else:
-            describe_images_owners = config.get("describe_images_owners", None)
-
-            if not describe_images_owners:
-                owners_filter = ["self"]
-            elif isinstance(describe_images_owners, str):
-                owners_filter = [describe_images_owners]
-            else:
-                owners_filter: List[str] = describe_images_owners
-
-        if name_match is None:
-            name_match = config.get("describe_images_name_match", None)
-
-        filters: List[FilterTypeDef] = [] if name_match is None else [{"Name": "name", "Values": [f"*{name_match}*"]}]
-
-        print(f"Describing images owned by {owners_filter} with name matching {name_match if name_match else '*'}")
-        response = ec2_client.describe_images(Owners=owners_filter, Filters=filters)
-
-    images: List[Image] = [
-        {
-            "Name": i.get("Name", None),
-            "ImageId": i["ImageId"],
-            "CreationDate": i["CreationDate"],
-            "RootDeviceName": i["RootDeviceName"],
-        }
-        for i in response["Images"]
-    ]
-
-    images = []
-    for i in response["Images"]:
-        image: Image = {
-            "Name": i.get("Name", None),
-            "ImageId": i["ImageId"],
-            "CreationDate": i["CreationDate"],
-            "RootDeviceName": i["RootDeviceName"],
-        }
-        if show_snapshot_id:
-            image["SnapshotId"] = i["BlockDeviceMappings"][0]["Ebs"]["SnapshotId"]
-        images.append(image)
-
-    return sorted(images, key=lambda i: i["CreationDate"], reverse=True)
-
-
-class AmiMatcher(NamedTuple):
-    owner: str
-    match_string: str
-
-
-amazon_base_account_id = "137112412989"
-canonical_account_id = "099720109477"
-
-ami_keywords = {
-    "amazon2": AmiMatcher(amazon_base_account_id, "amzn2-ami-hvm*x86_64-gp2"),
-    "ubuntu1604": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64"),
-    "ubuntu1804": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64"),
-    "ubuntu2004": AmiMatcher(canonical_account_id, "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"),
-}
 
 
 def launch(
@@ -209,25 +100,6 @@ def launch(
     # the response from run_instances above always contains an empty string
     # for PublicDnsName, so we call describe to get it
     return describe(config=config, name=name)
-
-
-def fetch_image(config: Dict[str, Any], ami: str) -> Image:
-    ami_matcher = ami_keywords.get(ami, None)
-    if ami_matcher:
-        try:
-            # lookup the latest ami by name match
-            ami_details = describe_images(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]
-        except IndexError:
-            raise RuntimeError(
-                f"Could not find ami with name matching {ami_matcher.match_string} owned by account {ami_matcher.owner}"
-            )
-    else:
-        try:
-            # lookup by ami id
-            ami_details = describe_images(config, ami=ami)[0]
-        except IndexError:
-            raise RuntimeError(f"Could not find {ami}")
-    return ami_details
 
 
 def describe(

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -3,7 +3,8 @@ import sys
 from typing import List
 
 import aec.command.compute_optimizer as compute_optimizer
-import aec.command.ec2 as ec2
+import aec.command.ec2_images as ec2_images
+import aec.command.ec2_instances as ec2_instances
 import aec.command.sqs as sqs
 import aec.command.ssm as ssm
 import aec.util.cli as cli
@@ -16,8 +17,10 @@ config_arg = Arg("--config", help="Section of the config file to use")
 
 
 def ami_arg_checker(s: str) -> str:
-    if not (s.startswith("ami-") or s in ec2.ami_keywords.keys()):
-        raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {[k for k in ec2.ami_keywords.keys()]}")
+    if not (s.startswith("ami-") or s in ec2_images.ami_keywords.keys()):
+        raise argparse.ArgumentTypeError(
+            f"must begin with 'ami-' or be one of {[k for k in ec2_images.ami_keywords.keys()]}"
+        )
     return s
 
 
@@ -28,56 +31,56 @@ configure_cli = [
 ]
 
 ec2_cli = [
-    Cmd(ec2.delete_image, [
+    Cmd(ec2_images.delete_image, [
         config_arg,
         Arg("ami", type=str, help="AMI id")
     ]),
-    Cmd(ec2.describe, [
+    Cmd(ec2_instances.describe, [
         config_arg,
         Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-it", "--include-terminated", action='store_true', dest='name_match', help="Include terminated instances"),
     ]),
-    Cmd(ec2.describe_images, [
+    Cmd(ec2_images.describe_images, [
         config_arg,
         Arg("--ami", type=str, help="Filter to this AMI id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
         Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
     ]),
-    Cmd(ec2.launch, [
+    Cmd(ec2_instances.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
-        Arg("ami", type=ami_arg_checker, help=f"AMI id or a one of the keywords {[k for k in ec2.ami_keywords.keys()]}"),
+        Arg("ami", type=ami_arg_checker, help=f"AMI id or a one of the keywords {[k for k in ec2_images.ami_keywords.keys()]}"),
         Arg("--volume-size", type=int, help="EBS volume size (GB)", default=100),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),
         Arg("--instance-type", type=str, help="Instance type", default="t2.medium"),
         Arg("--key-name", type=str, help="Key name"),
         Arg("--userdata", type=str, help="Path to user data file")
     ]),
-    Cmd(ec2.logs, [
+    Cmd(ec2_instances.logs, [
         config_arg,
         Arg("name", type=str, help="Name of instance")
     ]),
-    Cmd(ec2.modify, [
+    Cmd(ec2_instances.modify, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
         Arg("type", type=str, help="Type of instance")
     ]),
-    Cmd(ec2.share_image, [
+    Cmd(ec2_images.share_image, [
         config_arg,
         Arg("ami", type=str, help="AMI id"),
         Arg("account", type=str, help="Account id"),
     ]),
-    Cmd(ec2.start, [
+    Cmd(ec2_instances.start, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance")
     ]),
-    Cmd(ec2.stop, [
+    Cmd(ec2_instances.stop, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance")
     ]),
-    Cmd(ec2.terminate, [
+    Cmd(ec2_instances.terminate, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance")
     ])

--- a/tests/test_compute_optimizer.py
+++ b/tests/test_compute_optimizer.py
@@ -4,7 +4,7 @@ from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
 from aec.command.compute_optimizer import describe_instances_uptime
-from aec.command.ec2 import launch
+from aec.command.ec2_instances import launch
 
 
 @pytest.fixture

--- a/tests/test_ec2_images.py
+++ b/tests/test_ec2_images.py
@@ -1,0 +1,43 @@
+import pytest
+from moto import mock_ec2
+from moto.ec2.models import AMIS
+
+from aec.command.ec2_images import delete_image, describe_images, share_image
+
+
+@pytest.fixture
+def mock_aws_config():
+    mock = mock_ec2()
+    mock.start()
+    return {}
+
+
+def test_describe_images(mock_aws_config):
+    # describe images defined by moto
+    # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
+    canonical_account_id = "099720109477"
+    mock_aws_config["describe_images_owners"] = canonical_account_id
+    images = describe_images(config=mock_aws_config)
+
+    assert len(images) == 2
+    assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
+    assert images[1]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"
+
+
+def test_describe_images_name_match(mock_aws_config):
+    # describe images defined by moto
+    # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
+    canonical_account_id = "099720109477"
+    mock_aws_config["describe_images_owners"] = canonical_account_id
+    images = describe_images(config=mock_aws_config, name_match="*trusty*")
+
+    assert len(images) == 1
+    assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
+
+
+def test_delete_image(mock_aws_config):
+    delete_image(mock_aws_config, AMIS[0]["ami_id"])
+
+
+def test_share_image(mock_aws_config):
+    share_image(mock_aws_config, AMIS[0]["ami_id"], "123456789012")

--- a/tests/test_ec2_images.py
+++ b/tests/test_ec2_images.py
@@ -9,7 +9,10 @@ from aec.command.ec2_images import delete_image, describe_images, share_image
 def mock_aws_config():
     mock = mock_ec2()
     mock.start()
-    return {}
+
+    return {
+        "region": "ap-southeast-2",
+    }
 
 
 def test_describe_images(mock_aws_config):

--- a/tests/test_ec2_instances.py
+++ b/tests/test_ec2_instances.py
@@ -6,18 +6,7 @@ from moto import mock_ec2
 from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
-from aec.command.ec2 import (
-    delete_image,
-    describe,
-    describe_images,
-    launch,
-    logs,
-    modify,
-    share_image,
-    start,
-    stop,
-    terminate,
-)
+from aec.command.ec2_instances import describe, launch, logs, modify, start, stop, terminate
 
 
 @pytest.fixture
@@ -157,29 +146,6 @@ def describe_instance0(region_name, instance_id):
     return instances["Reservations"][0]["Instances"][0]
 
 
-def test_describe_images(mock_aws_config):
-    # describe images defined by moto
-    # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
-    canonical_account_id = "099720109477"
-    mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe_images(config=mock_aws_config)
-
-    assert len(images) == 2
-    assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
-    assert images[1]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721"
-
-
-def test_describe_images_name_match(mock_aws_config):
-    # describe images defined by moto
-    # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
-    canonical_account_id = "099720109477"
-    mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe_images(config=mock_aws_config, name_match="*trusty*")
-
-    assert len(images) == 1
-    assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
-
-
 def test_stop_start(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
 
@@ -198,10 +164,6 @@ def test_modify(mock_aws_config):
     assert instances[0]["Type"] == "c5.2xlarge"
 
 
-def test_delete_image(mock_aws_config):
-    delete_image(mock_aws_config, AMIS[0]["ami_id"])
-
-
 def test_terminate(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
 
@@ -212,10 +174,6 @@ def test_logs(mock_aws_config):
     launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
 
     logs(config=mock_aws_config, name="alice")
-
-
-def test_share_image(mock_aws_config):
-    share_image(mock_aws_config, AMIS[0]["ami_id"], "123456789012")
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
ec2.py was getting long, so I've split its functionality into ec2_images & ec2_instances