### PR TITLE
feat: ami subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,7 @@ Then run `make` to see the options for running checks, tests etc.
 
 ## Similar projects
 
-[awless](https://github.com/wallix/awless) is written in Go, and is an excellent substitute for awscli with
+[wallix/awless](https://github.com/wallix/awless) is written in Go, and is an excellent substitute for awscli with
 support for many AWS services. It has human friendly commands for use on the command line or in templates. Unlike `aec` its ec2 create instance command doesn't allow you to specify the EBS volume size, or add tags.
+
+[achiku/jungle](https://github.com/achiku/jungle) is written in Python, and incorporates a smaller subset of ec2 commands and doesn't launch new instances. It does however have an ec2 ssh command. It also supports other AWS services like ELB, EMR, RDS.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Defaults only need to be supplied once via a [config file](src/aec/config-exampl
 For examples see:
 
 - [EC2](docs/ec2.md) - manipulate EC2 instances by name, and launch them with tags and EBS volumes of any size, as per the settings in the configuration file (subnet, security group etc).
+- [AMI](docs/ami.md) - describe, delete and share images
 - [Compute Optimizer](docs/compute-optimizer.md) - show over-provisioned instances
 - [SSM](docs/ssm.md) - describe SSM agent info
 
@@ -42,7 +43,7 @@ For even faster access to aec subcommands, you may like to add the following ali
 
 ```
 alias ec2='COLUMNS=$COLUMNS aec ec2'
-alias co='COLUMNS=$COLUMNS aec co'
+alias ami='COLUMNS=$COLUMNS aec ami'
 ```
 
 `COLUMNS=$COLUMNS` will ensure output is formatted to the width of your terminal when piped.

--- a/docs/ami.md
+++ b/docs/ami.md
@@ -1,6 +1,6 @@
 # AMI
 
-To see the help, run `aec ami -h`
+Run `aec ami -h` for help:
 
 ```
 usage: aec ami [-h] {delete,describe,share} ...
@@ -15,13 +15,13 @@ subcommands:
     share               Share an AMI with another account.
 ```
 
-To list images owned by accounts specified in the config file:
+List images owned by accounts specified in the config file:
 
 ```
 ami describe
 ```
 
-To list ubuntu focal images owned by Canonical:
+List ubuntu focal images owned by Canonical:
 
 ```
 $ ami describe --owner 099720109477 -q "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"

--- a/docs/ami.md
+++ b/docs/ami.md
@@ -1,0 +1,46 @@
+# AMI
+
+To see the help, run `aec ami -h`
+
+```
+usage: aec ami [-h] {delete,describe,share} ...
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+subcommands:
+  {delete,describe,share}
+    delete              Deregister an AMI and delete its snapshot.
+    describe            List AMIs.
+    share               Share an AMI with another account.
+```
+
+To list images owned by accounts specified in the config file:
+
+```
+ami describe
+```
+
+To list ubuntu focal images owned by Canonical:
+
+```
+$ ami describe --owner 099720109477 -q "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64"
+Describing images owned by ['099720109477'] with name matching ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64
+
+  Name                                               ImageId                 CreationDate               RootDeviceName
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-07bfe0a3ec9dfcffa   2020-10-14T16:38:23.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0c43b23f011ba5061   2020-09-25T01:16:05.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-030bb5fda5f7e1896   2020-09-17T16:23:49.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0dba2cb6798deb6d8   2020-09-08T00:55:25.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-03f6f0014076ab3c5   2020-09-04T22:45:42.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-05cf2c352da0bfb2e   2020-08-18T17:26:37.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0758470213bdd23b1   2020-07-30T15:39:28.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-06c8ff16263f3db59   2020-07-21T00:35:15.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0d57c0143330e1fa7   2020-07-16T19:18:04.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-04e7b4117bb0488e4   2020-07-02T03:19:54.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0c40fbd26b9ac0da9   2020-06-26T16:09:27.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-02ae530dacc099fc9   2020-06-10T01:14:00.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-0e2512bd9da751ea8   2020-05-29T01:38:58.000Z   /dev/sda1
+  ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-…   ami-068663a3c619dd892   2020-04-23T11:35:02.000Z   /dev/sda1
+```

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -23,5 +23,4 @@ $ aec co over-provisioned
   i-01579de1b005846cb   instance A   m5.4xlarge      r5.2xlarge       CPU MAX 4.0    7 days 8 hours
   i-070c800a592bc6d73   instance B   m5.large        t3.large         CPU MAX 47.0   7 days 8 hours
   i-0ad199cc5b65c621d   instance C   m5.xlarge       r5.large         CPU MAX 30.0   23 days 8 hours
-
 ```

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -1,6 +1,6 @@
 # Compute Optimizer Usage
 
-To see the help, run `aec co -h`
+Run `aec co -h` for help:
 
 ```
 usage: aec co [-h] {over-provisioned} ...
@@ -13,7 +13,7 @@ subcommands:
     over-provisioned  Show recommendations for over-provisioned EC2 instances.
 ```
 
-To show recommendations for over-provisioned instances (eg: idle instances running for more than 30 hours):
+Show recommendations for over-provisioned instances (eg: idle instances running for more than 30 hours):
 
 ```
 $ aec co over-provisioned

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -1,6 +1,6 @@
 # EC2 Usage
 
-To see the help, run `aec ec2 -h`
+Run `aec ec2 -h` for help:
 
 ```
 usage: aec ec2 [-h] {describe,launch,logs,modify,start,stop,terminate} ...
@@ -19,19 +19,19 @@ subcommands:
     terminate           Terminate EC2 instances by name.
 ```
 
-To launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file
+Launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file:
 
 ```
 aec ec2 launch "lady gaga" ubuntu1804 --instance-type t2.medium --volume-size 50
 ```
 
-Stop the instance
+Stop the instance:
 
 ```
 aec ec2 stop "lady gaga"
 ```
 
-By default, commands will use the default profile as specified in the config file. To list ec2 instances using the non-default config `us`
+By default, commands will use the default profile as specified in the config file. To list ec2 instances using the non-default config `us`:
 
 ```
 aec ec2 describe --config us

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -3,29 +3,20 @@
 To see the help, run `aec ec2 -h`
 
 ```
-usage: aec ec2 [-h] {delete-image,describe,describe-images,launch,logs,modify,share-image,start,stop,terminate} ...
+usage: aec ec2 [-h] {describe,launch,logs,modify,start,stop,terminate} ...
 
 optional arguments:
   -h, --help            show this help message and exit
 
 subcommands:
-  {delete-image,describe,describe-images,launch,logs,modify,share-image,start,stop,terminate}
-    delete-image        Deregister an AMI and delete its snapshot.
+  {describe,launch,logs,modify,start,stop,terminate}
     describe            List EC2 instances in the region.
-    describe-images     List AMIs.
     launch              Launch a tagged EC2 instance with an EBS volume.
     logs                Show the system logs.
     modify              Change an instance's type.
-    share-image         Share an AMI with another account.
     start               Start EC2 instances by name.
     stop                Stop EC2 instances by name.
     terminate           Terminate EC2 instances by name.
-```
-
-To list AMIs (owned by accounts specified in the config file)
-
-```
-aec ec2 describe-images
 ```
 
 To launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file
@@ -44,4 +35,13 @@ By default, commands will use the default profile as specified in the config fil
 
 ```
 aec ec2 describe --config us
+
+  State     Name         Type          DnsName            LaunchTime         ImageId            InstanceId  
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  running   instance A   t2.micro      ec2-34-222-181-…   2020-08-31         ami-042e958219c…   i-0547be212903d…  
+                                                                22:33:29+00:00  
+  running   instance B   m5.large      ip-10-17-26-251…   2020-10-18         ami-0e40c8f9700…   i-0e0ea2dc778d7…  
+                                                                11:05:07+00:00  
+  stopped   instance C   t2.nano       ip-10-17-26-180…   2020-10-22         ami-0d5f76fa1b9…   i-0882dcea73a85…  
+                                                                19:29:14+00:00  
 ```

--- a/docs/ssm.md
+++ b/docs/ssm.md
@@ -1,6 +1,6 @@
 # SSM Usage
 
-To see the help, run `aec ssm -h`
+Run `aec ssm -h` for help:
 
 ```
 usage: aec ssm [-h] {describe} ...

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.6.0",
+    version="0.7.0",
     description="AWS EC2 CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -27,12 +27,12 @@ ami_keywords = {
 }
 
 
-def fetch_image(config: Dict[str, Any], ami: str) -> Image:
+def fetch(config: Dict[str, Any], ami: str) -> Image:
     ami_matcher = ami_keywords.get(ami, None)
     if ami_matcher:
         try:
             # lookup the latest ami by name match
-            ami_details = describe_images(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]
+            ami_details = describe(config, owner=ami_matcher.owner, name_match=ami_matcher.match_string)[0]
         except IndexError:
             raise RuntimeError(
                 f"Could not find ami with name matching {ami_matcher.match_string} owned by account {ami_matcher.owner}"
@@ -40,13 +40,13 @@ def fetch_image(config: Dict[str, Any], ami: str) -> Image:
     else:
         try:
             # lookup by ami id
-            ami_details = describe_images(config, ami=ami)[0]
+            ami_details = describe(config, ami=ami)[0]
         except IndexError:
             raise RuntimeError(f"Could not find {ami}")
     return ami_details
 
 
-def describe_images(
+def describe(
     config: Dict[str, Any],
     ami: Optional[str] = None,
     owner: Optional[str] = None,
@@ -105,19 +105,19 @@ def describe_images(
     return sorted(images, key=lambda i: i["CreationDate"], reverse=True)
 
 
-def delete_image(config: Dict[str, Any], ami: str) -> None:
+def delete(config: Dict[str, Any], ami: str) -> None:
     """Deregister an AMI and delete its snapshot."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
-    response = describe_images(config, ami, show_snapshot_id=True)
+    response = describe(config, ami, show_snapshot_id=True)
 
     ec2_client.deregister_image(ImageId=ami)
 
     ec2_client.delete_snapshot(SnapshotId=response[0]["SnapshotId"])
 
 
-def share_image(config: Dict[str, Any], ami: str, account: str) -> None:
+def share(config: Dict[str, Any], ami: str, account: str) -> None:
     """Share an AMI with another account."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -5,7 +5,7 @@ from typing import Any, AnyStr, Dict, List, Optional
 import boto3
 from mypy_boto3_ec2.type_defs import FilterTypeDef
 
-from aec.command.ec2_images import fetch_image
+import aec.command.ami as ami_cmd
 from aec.util.list import first_or_else
 
 
@@ -31,7 +31,7 @@ def launch(
     if not key_name:
         key_name = config["key_name"]
 
-    image = fetch_image(config, ami)
+    image = ami_cmd.fetch(config, ami)
 
     # TODO: support multiple subnets
     kwargs: Dict[str, Any] = {

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -2,9 +2,9 @@ import argparse
 import sys
 from typing import List
 
+import aec.command.ami as ami
 import aec.command.compute_optimizer as compute_optimizer
-import aec.command.ec2_images as ec2_images
-import aec.command.ec2_instances as ec2_instances
+import aec.command.ec2 as ec2
 import aec.command.ssm as ssm
 import aec.util.cli as cli
 import aec.util.config as config
@@ -16,10 +16,8 @@ config_arg = Arg("--config", help="Section of the config file to use")
 
 
 def ami_arg_checker(s: str) -> str:
-    if not (s.startswith("ami-") or s in ec2_images.ami_keywords.keys()):
-        raise argparse.ArgumentTypeError(
-            f"must begin with 'ami-' or be one of {[k for k in ec2_images.ami_keywords.keys()]}"
-        )
+    if not (s.startswith("ami-") or s in ami.ami_keywords.keys()):
+        raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {[k for k in ami.ami_keywords.keys()]}")
     return s
 
 
@@ -30,58 +28,61 @@ configure_cli = [
 ]
 
 ec2_cli = [
-    Cmd(ec2_images.delete_image, [
-        config_arg,
-        Arg("ami", type=str, help="AMI id")
-    ]),
-    Cmd(ec2_instances.describe, [
+    Cmd(ec2.describe, [
         config_arg,
         Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-it", "--include-terminated", action='store_true', dest='name_match', help="Include terminated instances"),
     ]),
-    Cmd(ec2_images.describe_images, [
-        config_arg,
-        Arg("--ami", type=str, help="Filter to this AMI id"),
-        Arg("--owner", type=str, help="Filter to this owning account"),
-        Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
-        Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
-    ]),
-    Cmd(ec2_instances.launch, [
+    Cmd(ec2.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
-        Arg("ami", type=ami_arg_checker, help=f"AMI id or a keyword to lookup the latest ami: {[k for k in ec2_images.ami_keywords.keys()]}"),
+        Arg("ami", type=ami_arg_checker, help=f"AMI id or a keyword to lookup the latest ami: {[k for k in ami.ami_keywords.keys()]}"),
         Arg("--volume-size", type=int, help="EBS volume size (GB)", default=100),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),
         Arg("--instance-type", type=str, help="Instance type", default="t2.medium"),
         Arg("--key-name", type=str, help="Key name"),
         Arg("--userdata", type=str, help="Path to user data file")
     ]),
-    Cmd(ec2_instances.logs, [
+    Cmd(ec2.logs, [
         config_arg,
         Arg("name", type=str, help="Name of instance")
     ]),
-    Cmd(ec2_instances.modify, [
+    Cmd(ec2.modify, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
         Arg("type", type=str, help="Type of instance")
     ]),
-    Cmd(ec2_images.share_image, [
+    Cmd(ec2.start, [
+        config_arg,
+        Arg("name", type=str, help="Name tag of instance")
+    ]),
+    Cmd(ec2.stop, [
+        config_arg,
+        Arg("name", type=str, help="Name tag of instance")
+    ]),
+    Cmd(ec2.terminate, [
+        config_arg,
+        Arg("name", type=str, help="Name tag of instance")
+    ])
+]
+
+ami_cli = [
+    Cmd(ami.delete, [
+        config_arg,
+        Arg("ami", type=str, help="AMI id")
+    ]),
+    Cmd(ami.describe, [
+        config_arg,
+        Arg("--ami", type=str, help="Filter to this AMI id"),
+        Arg("--owner", type=str, help="Filter to this owning account"),
+        Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
+        Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
+    ]),
+    Cmd(ami.share, [
         config_arg,
         Arg("ami", type=str, help="AMI id"),
         Arg("account", type=str, help="Account id"),
-    ]),
-    Cmd(ec2_instances.start, [
-        config_arg,
-        Arg("name", type=str, help="Name tag of instance")
-    ]),
-    Cmd(ec2_instances.stop, [
-        config_arg,
-        Arg("name", type=str, help="Name tag of instance")
-    ]),
-    Cmd(ec2_instances.terminate, [
-        config_arg,
-        Arg("name", type=str, help="Name tag of instance")
     ])
 ]
 
@@ -105,6 +106,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     cli.add_command_group(subparsers, "configure", "Configure subcommands", configure_cli)
     cli.add_command_group(subparsers, "ec2", "EC2 subcommands", ec2_cli, config.inject_config("~/.aec/ec2.toml"))
+    cli.add_command_group(subparsers, "ami", "AMI subcommands", ami_cli, config.inject_config("~/.aec/ec2.toml"))
     cli.add_command_group(
         subparsers,
         "co",

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -2,7 +2,7 @@ import pytest
 from moto import mock_ec2
 from moto.ec2.models import AMIS
 
-from aec.command.ec2_images import delete_image, describe_images, share_image
+from aec.command.ami import delete, describe, share
 
 
 @pytest.fixture
@@ -20,7 +20,7 @@ def test_describe_images(mock_aws_config):
     # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
     canonical_account_id = "099720109477"
     mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe_images(config=mock_aws_config)
+    images = describe(config=mock_aws_config)
 
     assert len(images) == 2
     assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
@@ -32,15 +32,15 @@ def test_describe_images_name_match(mock_aws_config):
     # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
     canonical_account_id = "099720109477"
     mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe_images(config=mock_aws_config, name_match="*trusty*")
+    images = describe(config=mock_aws_config, name_match="*trusty*")
 
     assert len(images) == 1
     assert images[0]["Name"] == "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727"
 
 
 def test_delete_image(mock_aws_config):
-    delete_image(mock_aws_config, AMIS[0]["ami_id"])
+    delete(mock_aws_config, AMIS[0]["ami_id"])
 
 
 def test_share_image(mock_aws_config):
-    share_image(mock_aws_config, AMIS[0]["ami_id"], "123456789012")
+    share(mock_aws_config, AMIS[0]["ami_id"], "123456789012")

--- a/tests/test_compute_optimizer.py
+++ b/tests/test_compute_optimizer.py
@@ -4,7 +4,7 @@ from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
 from aec.command.compute_optimizer import describe_instances_uptime
-from aec.command.ec2_instances import launch
+from aec.command.ec2 import launch
 
 
 @pytest.fixture

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -6,7 +6,7 @@ from moto import mock_ec2
 from moto.ec2 import ec2_backends
 from moto.ec2.models import AMIS
 
-from aec.command.ec2_instances import describe, launch, logs, modify, start, stop, terminate
+from aec.command.ec2 import describe, launch, logs, modify, start, stop, terminate
 
 
 @pytest.fixture


### PR DESCRIPTION
Splits out the ami related commands into their own subcommand `aec ami`:


```
usage: aec ami [-h] {delete,describe,share} ...
optional arguments:
  -h, --help            show this help message and exit
subcommands:
  {delete,describe,share}
    delete              Deregister an AMI and delete its snapshot.
    describe            List AMIs.
    share               Share an AMI with another account.
```