### PR TITLE
feat: instance id as name

### DIFF
--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -14,9 +14,9 @@ subcommands:
     launch              Launch a tagged EC2 instance with an EBS volume.
     logs                Show the system logs.
     modify              Change an instance's type.
-    start               Start EC2 instances.
-    stop                Stop EC2 instances.
-    terminate           Terminate EC2 instances.
+    start               Start EC2 instance.
+    stop                Stop EC2 instance.
+    terminate           Terminate EC2 instance.
 ```
 
 Launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file:

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -14,9 +14,9 @@ subcommands:
     launch              Launch a tagged EC2 instance with an EBS volume.
     logs                Show the system logs.
     modify              Change an instance's type.
-    start               Start EC2 instances by name.
-    stop                Stop EC2 instances by name.
-    terminate           Terminate EC2 instances by name.
+    start               Start EC2 instances.
+    stop                Stop EC2 instances.
+    terminate           Terminate EC2 instances.
 ```
 
 Launch a t2.medium instance named `lady gaga` with a 50gb EBS volume, with other settings read from the config file:
@@ -62,4 +62,10 @@ Show running or pending instances only:
 
 ```
 ec2 describe -r
+```
+
+Terminate an instance using its id:
+
+```
+ec2 terminate i-06814ad77d5177e5a
 ```

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = Path("README.md").read_text()
 
 setup(
     name="aec",
-    version="0.7.0",
+    version="0.7.1",
     description="AWS EC2 CLI",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -142,7 +142,7 @@ def describe(
 
 
 def start(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Start EC2 instances."""
+    """Start EC2 instance."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -163,7 +163,7 @@ def start(config: Config, name: str) -> List[Dict[str, Any]]:
 
 
 def stop(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Stop EC2 instances."""
+    """Stop EC2 instance."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -182,7 +182,7 @@ def pretty_name_or_id(name: str) -> str:
 
 
 def terminate(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Terminate EC2 instances."""
+    """Terminate EC2 instance."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -111,7 +111,9 @@ def describe(
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     filters: List[FilterTypeDef] = []
-    if name:
+    if name and name.startswith("i-"):
+        filters = [{"Name": "instance-id", "Values": [name]}]
+    elif name:
         filters = [{"Name": "tag:Name", "Values": [name]}]
     elif name_match:
         filters = [{"Name": "tag:Name", "Values": [f"*{name_match}*"]}]
@@ -149,7 +151,7 @@ def start(config: Config, name: str) -> List[Dict[str, Any]]:
     instances = describe(config, name)
 
     if not instances:
-        raise Exception(f"No instances named {name}")
+        raise Exception(f"No instances with {pretty_name_or_id(name)}")
 
     instance_ids = [instance["InstanceId"] for instance in instances]
     ec2_client.start_instances(InstanceIds=instance_ids)
@@ -168,22 +170,26 @@ def stop(config: Config, name: str) -> List[Dict[str, Any]]:
     instances = describe(config, name)
 
     if not instances:
-        raise Exception(f"No instances named {name}")
+        raise Exception(f"No instances with {pretty_name_or_id(name)}")
 
     response = ec2_client.stop_instances(InstanceIds=[instance["InstanceId"] for instance in instances])
 
     return [{"State": i["CurrentState"]["Name"], "InstanceId": i["InstanceId"]} for i in response["StoppingInstances"]]
 
 
+def pretty_name_or_id(name: str) -> str:
+    return f"instance id {name}" if name.startswith("i-") else f"name {name}"
+
+
 def terminate(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Terminate EC2 instances by name."""
+    """Terminate EC2 instances by name or instance id."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     instances = describe(config, name)
 
     if not instances:
-        raise Exception(f"No instances named {name}")
+        raise Exception(f"No instances with {pretty_name_or_id(name)}")
 
     response = ec2_client.terminate_instances(InstanceIds=[instance["InstanceId"] for instance in instances])
 
@@ -200,7 +206,7 @@ def modify(config: Config, name: str, type: str) -> List[Dict[str, Any]]:
     instances = describe(config, name)
 
     if not instances:
-        raise Exception(f"No instances named {name}")
+        raise Exception(f"No instances with {pretty_name_or_id(name)}")
 
     instance_id = instances[0]["InstanceId"]
     ec2_client.modify_instance_attribute(InstanceId=instance_id, InstanceType={"Value": type})
@@ -216,7 +222,7 @@ def logs(config: Config, name: str) -> str:
     instances = describe(config, name)
 
     if not instances:
-        raise Exception(f"No instances named {name}")
+        raise Exception(f"No instances with {pretty_name_or_id(name)}")
 
     instance_id = instances[0]["InstanceId"]
     response = ec2_client.get_console_output(InstanceId=instance_id)

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -142,7 +142,7 @@ def describe(
 
 
 def start(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Start EC2 instances by name."""
+    """Start EC2 instances."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -163,7 +163,7 @@ def start(config: Config, name: str) -> List[Dict[str, Any]]:
 
 
 def stop(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Stop EC2 instances by name."""
+    """Stop EC2 instances."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -182,7 +182,7 @@ def pretty_name_or_id(name: str) -> str:
 
 
 def terminate(config: Config, name: str) -> List[Dict[str, Any]]:
-    """Terminate EC2 instances by name or instance id."""
+    """Terminate EC2 instances."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -30,7 +30,7 @@ configure_cli = [
 ec2_cli = [
     Cmd(ec2.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag."),
+        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-r", "--show-running-only", action='store_true', help="Show running or pending instances only"),
         Arg("-it", "--include-terminated", action='store_true', help="Include terminated instances"),
@@ -47,24 +47,24 @@ ec2_cli = [
     ]),
     Cmd(ec2.logs, [
         config_arg,
-        Arg("name", type=str, help="Name of instance")
+        Arg("name", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.modify, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance"),
+        Arg("name", type=str, help="Name tag of instance or instance id"),
         Arg("type", type=str, help="Type of instance")
     ]),
     Cmd(ec2.start, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance")
+        Arg("name", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.stop, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance")
+        Arg("name", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.terminate, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance")
+        Arg("name", type=str, help="Name tag of instance or instance id")
     ])
 ]
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -151,6 +151,15 @@ def test_describe_running_only(mock_aws_config):
     assert instances[0]["Name"] == "alice"
 
 
+def test_describe_instance_id(mock_aws_config):
+    instances = launch(mock_aws_config, "alice", AMIS[0]["ami_id"])
+    instance_id = instances[0]["InstanceId"]
+
+    instances = describe(config=mock_aws_config, name=instance_id)
+    assert len(instances) == 1
+    assert instances[0]["Name"] == "alice"
+
+
 def describe_instance0(region_name, instance_id):
     ec2_client = boto3.client("ec2", region_name=region_name)
     instances = ec2_client.describe_instances(InstanceIds=[instance_id])


### PR DESCRIPTION
Allow an instance id to be used where name is, eg:
```
ec2 terminate i-06814ad77d5177e5a
```

