### PR TITLE
chore: remove importlib_metadata (no longer needed as explicit dep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,9 @@
     "lockfileVersion": 1,
     "dependencies": {
         "pyright": {
-            "version": "1.1.82",
-            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.82.tgz",
-            "integrity": "sha512-sSYrN9ziOKTLdo7HwP8vlU8pLhY7KDQ9hGK7sW4S2pNn6pAe2ewUjD5Gk4AAbKc13qQ9za9cdthhT0Gk60L7mA==",
+            "version": "1.1.87",
+            "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.87.tgz",
+            "integrity": "sha512-yiZ79Jzv0bIAQW3rlJip8a4Wy8IRU1zABG1/eOOWN3s7yn8jTWTld5QhraIRVID/YhkzmNj3sox43SeCj6yelA==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "devDependencies": {
-        "pyright": "1.1.82"
+        "pyright": "1.1.87"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ setup(
         "dev": [
             "black==20.8b1",
             "darglint==1.5.8",
-            # pin importlib_metadata to avoid conflict, must be <2
-            "importlib_metadata==1.7.0",
             "isort==5.6.4",
             "flake8==3.8.4",
             "flake8-annotations==2.4.1",


### PR DESCRIPTION
and bump pyright to 1.1.87