### PR TITLE
Add boto3 to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=[
+        "boto3==1.17.17.0",
         "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.17.0",
         "pytoml==0.1.21",
         "pytz==2021.1",

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(
     include_package_data=True,
     install_requires=[
         "boto3==1.17.17.0",
+        "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.17.0",
         "pytoml==0.1.21",
         "pytz==2021.1",
         "rich==9.12.4",
     ],
     extras_require={
         "dev": [
-            "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.17.0",
             "black==20.8b1",
             "darglint==1.7.0",
             "isort==5.7.0",

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(
     include_package_data=True,
     install_requires=[
         "boto3==1.17.17.0",
-        "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.17.0",
         "pytoml==0.1.21",
         "pytz==2021.1",
         "rich==9.12.4",
     ],
     extras_require={
         "dev": [
+            "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.17.0",
             "black==20.8b1",
             "darglint==1.7.0",
             "isort==5.7.0",


### PR DESCRIPTION
Boto3 doesn't seem to be installed through a fresh install

```
$ aec ec2  --h
ModuleNotFoundError: No module named 'boto3'
```

Also `boto3-stubs` makes more sense as a dev dependency since it's an editor plug in