### PR TITLE
Update README to use pip instead of pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ For examples see:
 
 ## Install
 
-Run the following to install the latest master version using [pipx](https://github.com/pipxproject/pipx):
+Run the following to install the latest master version using pip:
 
 ```
-pipx install git+https://github.com/seek-oss/aec.git
+pip install git+https://github.com/seek-oss/aec.git
 ```
 
-If you have previously installed aec, run `pipx upgrade aec` to upgrade to the latest version.
+If you have previously installed aec, run `pip upgrade aec` to upgrade to the latest version.
 
 ## Configure
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ Run the following to install the latest master version using pip:
 pip install git+https://github.com/seek-oss/aec.git
 ```
 
-If you have previously installed aec, run `pip upgrade aec` to upgrade to the latest version.
+If you have previously installed aec, run the following to upgrade to the latest version:
+```
+pip install --upgrade git+https://github.com/seek-oss/aec.git
+```
 
 ## Configure
 


### PR DESCRIPTION
It seems like `pipx` doesn't play nice if we try to install it from within a virtual environment

Also I think it's better to have `pip` in the instruction since it's a standard tool. `pipx` can be a personal choice since it might not work on every kind of set up.