### PR TITLE
use .venv/ instead of venv/

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length=120
-exclude = .git,__pycache__,node_modules,typings,.tox,build,dist,venv
+exclude = .git,__pycache__,node_modules,typings,.tox,build,dist,.venv
 
 ignore =
     # The following are ignored because they will be fixed by black/isort

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Cache virtualenv
       uses: actions/cache@v2
       with:
-        path: venv
+        path: .venv
         key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('setup.py') }}
     - name: install
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ typings/
 .tox/
 pip-wheel-metadata/
 node_modules/
-venv/
+.venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     hooks:
       - id: black
         name: black
-        entry: venv/bin/black
+        entry: .venv/bin/black
         language: system
         types: [python]
       - id: isort
         name: isort
-        entry: venv/bin/isort
+        entry: .venv/bin/isort
         language: system
         types: [python]
   - repo: https://github.com/myint/docformatter
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: flake8
         name: flake8
-        entry: venv/bin/flake8
+        entry: .venv/bin/flake8
         language: system
         types: [python]
   # these hooks require the project's virtualenv

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ SHELL = /bin/bash -o pipefail
 help:
 	@awk '/^##.*$$/,/^[~\/\.0-9a-zA-Z_-]+:/' $(MAKEFILE_LIST) | awk '!(NR%2){print $$0p}{p=$$0}' | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort
 
-venv = venv
+venv = .venv
 pip := $(venv)/bin/pip
 src := src tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ aggressive = 1
 line_length = 120
 multi_line_output = 3
 include_trailing_comma = true
-skip = [ ".tox", "dist", "node_modules" , "venv", "build", ".git", "typings"]
+skip = [ ".tox", "dist", "node_modules" , ".venv", "build", ".git", "typings"]


### PR DESCRIPTION
Change the virtualenv location from _venv/_ to _.venv/_.
    
dot dirs are automatically excluded by many cli tools (eg: fzf, rg) and most of the time we want to ignore the contents of the virtual env.