### PR TITLE
refactor: remove boto stubs from runtime requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "boto3==1.17.62",
-        "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.62.0",
         "pytoml==0.1.21",
         "pytz==2021.1",
         "rich==10.1.0",
@@ -29,6 +28,7 @@ setup(
     extras_require={
         "dev": [
             "black==21.4b2",
+            "boto3-stubs[ec2,compute-optimizer,ssm]==1.17.62.0",
             "darglint==1.8.0",
             "isort==5.8.0",
             "flake8==3.9.1",

--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -1,7 +1,10 @@
-from typing import List, NamedTuple, Optional
+from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 import boto3
-from mypy_boto3_ec2.type_defs import FilterTypeDef
+
+if TYPE_CHECKING:
+    from mypy_boto3_ec2.type_defs import FilterTypeDef
+
 from typing_extensions import TypedDict
 
 from aec.util.config import Config

--- a/src/aec/command/compute_optimizer.py
+++ b/src/aec/command/compute_optimizer.py
@@ -1,10 +1,12 @@
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 import boto3
 import pytz
 from dateutil import relativedelta
-from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
+
+if TYPE_CHECKING:
+    from mypy_boto3_compute_optimizer.type_defs import UtilizationMetricTypeDef
 
 from aec.util.config import Config
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -1,13 +1,15 @@
 import os
 import os.path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import boto3
-from mypy_boto3_ec2.type_defs import FilterTypeDef
 
 import aec.command.ami as ami_cmd
 import aec.util.instance as instance
 from aec.util.config import Config
+
+if TYPE_CHECKING:
+    from mypy_boto3_ec2.type_defs import FilterTypeDef
 
 
 def is_ebs_optimizable(instance_type: str) -> bool:

--- a/src/aec/util/instance.py
+++ b/src/aec/util/instance.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
-from mypy_boto3_ec2.type_defs import InstanceTypeDef
+if TYPE_CHECKING:
+    from mypy_boto3_ec2.type_defs import InstanceTypeDef
 
 
-def tag(instance: InstanceTypeDef, key: str) -> Optional[str]:
+def tag(instance: "InstanceTypeDef", key: str) -> Optional[str]:
     tag_value = [t["Value"] for t in instance.get("Tags", []) if t["Key"] == key]
     return tag_value[0] if tag_value else None


### PR DESCRIPTION
stubs shouldn't be needed at runtime, so only import them when type checking and convert function signature annotations that use them to strings.  