### PR TITLE
feat: create gp3 volumes

### DIFF
--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -65,7 +65,7 @@ def launch(
                 "Ebs": {
                     "VolumeSize": volume_size,
                     "DeleteOnTermination": True,
-                    "VolumeType": "gp2",
+                    "VolumeType": "gp3",
                     "Encrypted": encrypted,
                 },
             }


### PR DESCRIPTION
create gp3 volumes instead of gp2

gp3 vs gp2:
* 20% lower price
* 4x max throughput & burstable capacity

https://aws.amazon.com/about-aws/whats-new/2020/12/introducing-new-amazon-ebs-general-purpose-volumes-gp3/