### PR TITLE
feat: csv output

### DIFF
--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -99,7 +99,7 @@ ec2 tags -v
 Show output as csv instead of a table (works with any command)
 
 ```
-ec2 tags -v
+ec2 tags -v -o csv
 VolumeId,Name,Tags
 vol-0439c5ed37f6d455e,awesome-vol,"Name=awesome-vol, Owner=jane"
 ```

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -96,7 +96,7 @@ ec2 tags -v
   vol-0439c5ed37f6d455e   awesome-vol   Name=awesome-vol, Owner=jane
 ```
 
-Show output as csv instead of a table
+Show output as csv instead of a table (works with any command)
 
 ```
 ec2 tags -v

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -93,7 +93,15 @@ ec2 tags -v
 
   VolumeId              Name          Tags
  ───────────────────────────────────────────────────────────────────
-  i-099fe44f811245812   awesome-vol   Name=awesome-vol, Owner=jane
+  vol-0439c5ed37f6d455e   awesome-vol   Name=awesome-vol, Owner=jane
+```
+
+Show output as csv instead of a table
+
+```
+ec2 tags -v
+VolumeId,Name,Tags
+vol-0439c5ed37f6d455e,awesome-vol,"Name=awesome-vol, Owner=jane"
 ```
 
 Terminate an instance using its id:

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -132,9 +132,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(args: List[str] = sys.argv[1:]) -> None:
     result, output_format = cli.dispatch(build_parser(), args)
-    print(output_format)
-    print(type(output_format))
-    display.pretty_print(result)
+    display.pretty_print(result, output_format)
 
 
 if __name__ == "__main__":

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -131,7 +131,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(args: List[str] = sys.argv[1:]) -> None:
-    result = cli.dispatch(build_parser(), args)
+    result, output_format = cli.dispatch(build_parser(), args)
+    print(output_format)
+    print(type(output_format))
     display.pretty_print(result)
 
 

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -3,7 +3,9 @@
 import inspect
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace, _SubParsersAction
 from typing import Any, Callable, List, Optional, Tuple
-from enum import Enum
+
+from aec.util.display import OutputFormat
+
 
 class Arg:
     def __init__(self, *args: Any, **kwargs: Any):
@@ -37,9 +39,6 @@ class Cmd:
         elif not self.args and call_me_num_args > 0:
             raise Exception(f"{self.call_me.__name__} has {call_me_num_args} args but none defined for the cli")
 
-class OutputFormat(Enum):
-    table = 'table'
-    csv = 'csv'
 
 def usage_exit(parser: ArgumentParser) -> Callable[[], None]:
     def inner() -> None:
@@ -73,6 +72,7 @@ def add_command_group(
                 parser.add_argument(*arg.args, **arg.kwargs)
         parser.add_argument("-o", "--output", choices=OutputFormat.__members__, help="Output format", default="table")
 
+
 def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat]:
     pargs = parser.parse_args(args)
 
@@ -93,4 +93,3 @@ def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat
     delattr(pargs, "output")
 
     return (call_me(**vars(pargs)), output_format)
-

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -68,7 +68,7 @@ def add_command_group(
         if cmd.args:
             for arg in cmd.args:
                 parser.add_argument(*arg.args, **arg.kwargs)
-
+        parser.add_argument("-o", "--output", choices=["table", "csv"], help="Output format", default="table")
 
 def dispatch(parser: ArgumentParser, args: List[str]) -> Any:
     pargs = parser.parse_args(args)
@@ -84,4 +84,10 @@ def dispatch(parser: ArgumentParser, args: List[str]) -> Any:
     call_me = pargs.call_me
     # remove call_me arg because the call_me function doesn't expect it
     delattr(pargs, "call_me")
-    return call_me(**vars(pargs))
+
+    # remove output because that's injected above and the call_me function doesn't expect it
+    output_format = pargs.output
+    delattr(pargs, "output")
+
+    return (call_me(**vars(pargs)), output_format)
+

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -70,7 +70,11 @@ def add_command_group(
         if cmd.args:
             for arg in cmd.args:
                 parser.add_argument(*arg.args, **arg.kwargs)
-        parser.add_argument("-o", "--output", choices=OutputFormat.__members__, help="Output format", default="table")
+
+        # add output arg to every command
+        parser.add_argument(
+            "-o", "--output", choices=OutputFormat.__members__, help="Output format", default=OutputFormat.table.value
+        )
 
 
 def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat]:

--- a/src/aec/util/display.py
+++ b/src/aec/util/display.py
@@ -22,32 +22,6 @@ def as_table(dicts: Optional[Sequence[Dict[str, Any]]], keys: Optional[List[str]
     return [keys] + [[str(d.get(f, "")) if d.get(f, "") else None for f in keys] for d in dicts]  # type: ignore
 
 
-def pretty_table(table: Optional[Sequence[Sequence[Optional[str]]]]) -> str:
-    """Formats a table as a pretty string for printing."""
-    if not table:
-        return ""
-
-    padding = 2
-    col_width = [0] * len(table[0])
-    for row in table:
-        for idx, col in enumerate(row):
-            if col is not None and len(col) > col_width[idx]:
-                col_width[idx] = len(col)
-
-    return "\n".join(
-        [
-            "".join(
-                [
-                    "".join(
-                        (col if col is not None else "").ljust(col_width[idx] + padding) for idx, col in enumerate(row)
-                    )
-                ]
-            )
-            for row in table
-        ]
-    )
-
-
 def pretty_print(result: Any) -> None:
     """print table/json, instead of showing a dict, or list of dicts."""
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -2,7 +2,7 @@ import datetime
 
 from dateutil.tz import tzutc
 
-from aec.util.display import as_table, pretty_table
+from aec.util.display import as_table
 
 
 def test_as_table():
@@ -34,24 +34,3 @@ def test_as_table_with_none():
 
 def test_as_table_empty_list():
     assert as_table([]) == []
-
-
-def test_pretty():
-    table = [["a", "b", "c"], ["aaaaaaaaaa", "b", "c"], ["a", "bbbbbbbbbb", "c"]]
-    expected = "a           b           c  \naaaaaaaaaa  b           c  \na           bbbbbbbbbb  c  "
-    actual = pretty_table(table)
-    assert actual == expected
-
-
-def test_pretty_with_none():
-    table = [["a", "b", "c"], [None, "e", "f"]]
-    expected = "a  b  c  \n   e  f  "
-    actual = pretty_table(table)
-    assert actual == expected
-
-
-def test_pretty_with_empty_table():
-    table = []
-    expected = ""
-    actual = pretty_table(table)
-    assert actual == expected


### PR DESCRIPTION
Show output as csv instead of a table (works with any command)

```
ec2 tags -v -o csv
VolumeId,Name,Tags
vol-0439c5ed37f6d455e,awesome-vol,"Name=awesome-vol, Owner=jane"
```

refactor: remove pretty_table because it's not being used