### PR TITLE
fix: NameError: name 'UtilizationMetricTypeDef' is not defined

### DIFF
--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 import boto3

--- a/src/aec/command/compute_optimizer.py
+++ b/src/aec/command/compute_optimizer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import os.path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional

--- a/src/aec/util/display.py
+++ b/src/aec/util/display.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import csv
 import enum
 import json
 import sys
-from typing import Any, Dict, List, Optional, Sequence, Union, cast
+from typing import Any, Dict, List, Optional, Sequence, cast
 
 from rich import box
 from rich.console import Console
@@ -30,7 +32,7 @@ def as_table(dicts: Sequence[Dict[str, Any]], keys: Optional[List[str]] = None) 
     return [keys] + [[str(d.get(f, "")) if d.get(f, "") else None for f in keys] for d in dicts]  # type: ignore
 
 
-def pretty_print(result: Union[List[Dict[str, Any]], Dict, str, None], output_format: OutputFormat) -> None:
+def pretty_print(result: List[Dict[str, Any]] | Dict | str | None, output_format: OutputFormat) -> None:
     """print table/json, instead of showing a dict, or list of dicts."""
 
     console = Console()

--- a/src/aec/util/tags.py
+++ b/src/aec/util/tags.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2.type_defs import InstanceTypeDef, VolumeTypeDef
 
 
-def get_value(instance: "InstanceTypeDef | VolumeTypeDef", key: str) -> Optional[str]:
+def get_value(instance: InstanceTypeDef | VolumeTypeDef, key: str) -> Optional[str]:
     tag_value = [t["Value"] for t in instance.get("Tags", []) if t["Key"] == key]
     return tag_value[0] if tag_value else None


### PR DESCRIPTION
`from __future__ import annotations` will [treat annotations as strings at runtime](https://adamj.eu/tech/2021/05/15/python-type-hints-future-annotations/)

This fixes:
```
$ aec co over-provisioned
Traceback (most recent call last):
  File "/Users/tekumara/code/aec/.venv/bin/aec", line 33, in <module>
    sys.exit(load_entry_point('aec-cli', 'console_scripts', 'aec')())
  File "/Users/tekumara/code/aec/src/aec/main.py", line 134, in main
    result = cli.dispatch(build_parser(), args)
  File "/Users/tekumara/code/aec/src/aec/util/cli.py", line 87, in dispatch
    return call_me(**vars(pargs))
  File "/Users/tekumara/code/aec/src/aec/command/compute_optimizer.py", line 17, in over_provisioned
    def util(metric: UtilizationMetricTypeDef) -> str:
NameError: name 'UtilizationMetricTypeDef' is not defined
```

It also enables use of the Python 3.10 union type shorthand,ie:
`InstanceTypeDef | VolumeTypeDef` instead of `Union[InstanceTypeDef, VolumeTypeDef]`