### PR TITLE
fix: Could not assign item in TypedDict Type "str" cannot be assigned to type "InstanceTypeType"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
     "devDependencies": {
-        "pyright": "1.1.187"
+        "pyright": "1.1.209"
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     install_requires=[
-        "boto3==1.20.26",
+        "boto3==1.20.51",
         "importlib_resources==5.4.0",
         "pytoml==0.1.21",
         "pytz==2021.3",
@@ -30,7 +30,7 @@ setup(
     extras_require={
         "dev": [
             "black==21.5b2",
-            "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.20.26",
+            "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.20.51",
             "darglint==1.8.1",
             "isort==5.10.1",
             "flake8==4.0.1",

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import os.path
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import boto3
 from typing_extensions import TypedDict
@@ -12,6 +12,7 @@ from aec.util.errors import HandledError, NoInstancesError
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2.type_defs import BlockDeviceMappingTypeDef, FilterTypeDef, TagTypeDef
+    from mypy_boto3_ec2.literals import InstanceTypeType
 
 import aec.command.ami as ami_cmd
 import aec.util.tags as util_tags
@@ -100,7 +101,7 @@ def launch(
         raise HandledError("Please provide a key name")
 
     if instance_type:
-        runargs["InstanceType"] = instance_type
+        runargs["InstanceType"] = cast("InstanceTypeType", instance_type)
         runargs["EbsOptimized"] = is_ebs_optimizable(instance_type)
 
     tags = [{"Key": "Name", "Value": name}]
@@ -167,6 +168,7 @@ def describe(
     include_terminated: bool = False,
     show_running_only: bool = False,
     sort_by: str = "State,Name",
+    columns: Optional[str] = None,
 ) -> List[Instance]:
     """List EC2 instances in the region."""
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -168,7 +168,6 @@ def describe(
     include_terminated: bool = False,
     show_running_only: bool = False,
     sort_by: str = "State,Name",
-    columns: Optional[str] = None,
 ) -> List[Instance]:
     """List EC2 instances in the region."""
 


### PR DESCRIPTION
using InstanceTypeType literal introduced in https://github.com/vemel/mypy_boto3_builder/issues/71

also bump to latest version of pyright + boto + boto stubs
