### PR TITLE
refactor: add packaging requirements using build-system (ie: pep517 build)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,7 @@ dist: $(venv)
 	rm -rf src/*.egg-info
 	# remove previous builds
 	rm -rf dist/* build/*
-	$(venv)/bin/python setup.py sdist
-	$(venv)/bin/python setup.py bdist_wheel
+	$(venv)/bin/python -m build --sdist --wheel
 
 ## test the wheel is correctly packaged
 test-dist: tmp_dir:=$(shell mktemp -d)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ $(pip):
 # create venv using system python even when another venv is active
 	PATH=$${PATH#$${VIRTUAL_ENV}/bin:} python3 -m venv --clear $(venv)
 	$(venv)/bin/python --version
-	$(pip) install pip~=22.0 setuptools~=60.8 wheel~=0.37
+	$(pip) install pip~=22.0
 
 $(venv): setup.py $(pip)
 	$(pip) install -e '.[dev]'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 # use PyCharm default line length of 120
 
+[build-system]
+requires = ["setuptools", "wheel"]
+
 [tool.black]
 line-length = 120
-
-[tool.autopep8]
-max_line_length = 120
-aggressive = 1
 
 [tool.isort]
 # make isort compatible with black

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     extras_require={
         "dev": [
             "black==22.1.0",
+            "build~=0.7",
             "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.20.54",
             "darglint==1.8.1",
             "isort==5.10.1",


### PR DESCRIPTION
Add [packaging requirements](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#package-requirement) using `build-system` (ie: [PEP 517](https://www.python.org/dev/peps/pep-0517/) style) 

This tells `pip install` to install setuptools and wheel if they are not present when installing the package. For more info see https://github.com/tekumara/python-typed-template/commit/74b8e90a839aa141d3af15fa562d646ba3a50f50