### PR TITLE
build: use cog to generate help docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --warn-undefined-variables
 SHELL = /bin/bash -o pipefail
 .DEFAULT_GOAL := help
-.PHONY: help install check lint pyright test hooks install-hooks dist publish
+.PHONY: help install check lint pyright test hooks install-hooks docs dist publish
 
 ## display help message
 help:
@@ -51,6 +51,10 @@ pyright: node_modules $(venv)
 ## run tests
 test: $(venv)
 	$(venv)/bin/pytest
+
+## generate docs
+docs: $(venv)
+	cog -r docs/*.md
 
 ## build distribution
 dist: $(venv)

--- a/docs/ami.md
+++ b/docs/ami.md
@@ -2,6 +2,11 @@
 
 Run `aec ami -h` for help:
 
+<!-- [[[cog
+import cog
+from aec.main import build_parser
+cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ami'].format_help()}```")
+]]] -->
 ```
 usage: aec ami [-h] {delete,describe,share} ...
 
@@ -14,6 +19,7 @@ subcommands:
     describe            List AMIs.
     share               Share an AMI with another account.
 ```
+<!-- [[[end]]] -->
 
 List images owned by accounts specified in the config file:
 

--- a/docs/compute-optimizer.md
+++ b/docs/compute-optimizer.md
@@ -2,6 +2,11 @@
 
 Run `aec co -h` for help:
 
+<!-- [[[cog
+import cog
+from aec.main import build_parser
+cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['co'].format_help()}```")
+]]] -->
 ```
 usage: aec co [-h] {over-provisioned} ...
 
@@ -12,6 +17,7 @@ subcommands:
   {over-provisioned}
     over-provisioned  Show recommendations for over-provisioned EC2 instances.
 ```
+<!-- [[[end]]] -->
 
 Show recommendations for over-provisioned instances (eg: idle instances running for more than 30 hours):
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -2,6 +2,11 @@
 
 Run `aec ec2 -h` for help:
 
+<!-- [[[cog
+import cog
+from aec.main import build_parser
+cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ec2'].format_help()}```")
+]]] -->
 ```
 usage: aec ec2 [-h] {create-key-pair,describe,launch,logs,modify,start,stop,tag,tags,status,templates,terminate} ...
 
@@ -23,6 +28,7 @@ subcommands:
     templates           Describe launch templates.
     terminate           Terminate EC2 instance.
 ```
+<!-- [[[end]]] -->
 
 Launch an instance named `food baby` from the [ec2 launch template](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html) named `yummy`:
 

--- a/docs/ssm.md
+++ b/docs/ssm.md
@@ -2,10 +2,13 @@
 
 Run `aec ssm -h` for help:
 
+<!-- [[[cog
+import cog
+from aec.main import build_parser
+cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ssm'].format_help()}```")
+]]] -->
 ```
-usage: aec ssm [-h]
-               {commands,compliance-summary,describe,invocations,output,patch,patch-summary,run}
-               ...
+usage: aec ssm [-h] {commands,compliance-summary,describe,invocations,output,patch,patch-summary,run} ...
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -13,15 +16,15 @@ optional arguments:
 subcommands:
   {commands,compliance-summary,describe,invocations,output,patch,patch-summary,run}
     commands            List commands by instance.
-    compliance-summary  Compliance summary for running instances.
+    compliance-summary  Compliance summary for running instances that have run the patch baseline.
     describe            List running instances with the SSM agent.
     invocations         List invocations of a command across instances.
     output              Fetch output of a command from S3.
     patch               Scan or install AWS patch baseline.
-    patch-summary       Patch summary for all instances.
-    run                 Run a shell script on instance(s). Script is read from
-                        stdin.
+    patch-summary       Patch summary for all instances that have run the patch baseline.
+    run                 Run a shell script on instance(s). Script is read from stdin.
 ```
+<!-- [[[end]]] -->
 
 ## Examples
 
@@ -62,10 +65,10 @@ Compliance status of running instances (that have run the patch baseline):
 ```
 ssm compliance-summary
 
-  InstanceId            Name                    Status          NonCompliantCount   Last operation time  
+  InstanceId            Name                    Status          NonCompliantCount   Last operation time
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-01579de1b005846cb   awesome-instance        COMPLIANT                           2021-06-05 22:08:26+10:00  
-  i-0f194c8d697f35240   even-better-instance    NON_COMPLIANT   22                  2021-06-05 22:11:53+10:00  
+  i-01579de1b005846cb   awesome-instance        COMPLIANT                           2021-06-05 22:08:26+10:00
+  i-0f194c8d697f35240   even-better-instance    NON_COMPLIANT   22                  2021-06-05 22:11:53+10:00
 ```
 
 Patch an instance but don't reboot:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             "black==22.3.0",
             "build~=0.7",
             "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.21.27",
+            "cogapp~=3.3",
             "darglint==1.8.1",
             "isort==5.10.1",
             "flake8==4.0.1",

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -172,7 +172,8 @@ ssm_cli = [
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="aws ec2 cli")
+    # prog=aec so that we run in cog the program name isn't cog
+    parser = argparse.ArgumentParser(prog="aec", description="aws ec2 cli")
     subparsers = parser.add_subparsers(title="commands")
 
     cli.add_command_group(subparsers, "configure", "Configure subcommands", configure_cli)


### PR DESCRIPTION
use [cog](https://github.com/nedbat/cog) to automate the generation of the help snippets in the docs