### PR TITLE
build: don't include .pyc files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 # needed by setup.py
 include README.md
-graft src
+recursive-include src/aec/config-example *.toml *.yaml


### PR DESCRIPTION
sdist and wheels don't normally include `__pycache__/*.pyc` files, which were being included by `graft src`.

by being more selective they will no longer be included.