### PR TITLE
chore: bump deps

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('setup.py') }}
+        key: ${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-venv-${{ hashFiles('pyproject.toml') }}
     - name: make install
       if: steps.cache-venv.outputs.cache-hit != 'true'
       run: make install
@@ -51,6 +51,6 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{ env.version }}"
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
+    # - name: Setup tmate session
+    #   if: ${{ failure() }}
+    #   uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -51,3 +51,6 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{ env.version }}"
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,30 +8,30 @@ keywords = ["AWS", "EC2", "command line", "cli"]
 classifiers = ["License :: OSI Approved :: MIT License"]
 requires-python = ">=3.6"
 dependencies = [
-    "boto3==1.24.1",
-    "importlib_resources==5.7.1",
+    "boto3==1.24.41",
+    "importlib_resources==5.9.0",
     "pytoml==0.1.21",
     "pytz==2022.1",
-    "rich==12.4.4",
-    "typing_extensions==4.2.0",
+    "rich==12.5.1",
+    "typing_extensions==4.3.0",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "black==22.3.0",
+    "black~=22.6",
     "build~=0.7",
-    "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.21.27",
+    "boto3-stubs[ec2,compute-optimizer,ssm,s3]==1.24.41",
     "cogapp~=3.3",
-    "darglint==1.8.1",
-    "isort==5.10.1",
-    "flake8==4.0.1",
+    "darglint~=1.8",
+    "isort~=5.10",
+    "flake8~=4.0",
     "flake8-annotations~=2.9",
-    "flake8-colors==0.1.9",
-    "moto[ec2]==3.1.11",
-    "pre-commit~=2.19",
-    "pyfakefs==4.5.6",
+    "flake8-colors~=0.1",
+    "moto[ec2]==3.1.16",
+    "pre-commit~=2.20",
+    "pyfakefs~=4.6",
     "pytest~=7.1",
-    "pytest-mock==3.7.0",
+    "pytest-mock~=3.8",
     "twine~=4.0",
 ]
 

--- a/toast.yml
+++ b/toast.yml
@@ -20,10 +20,9 @@ tasks:
     input_paths:
       - Makefile
       - setup.py
+      - pyproject.toml
       - README.md
       - package.json
-      - package-lock.json
-      - .install-typings-boto3.sh
       - src/
     environment:
       CI: true
@@ -35,7 +34,6 @@ tasks:
     input_paths:
       - .darglint
       - .flake8
-      - pyproject.toml
       - pyrightconfig.json
       - tests/
     environment:


### PR DESCRIPTION
also fixes the build cache and toast.yml to use pyproject.toml introduced in #372 