### PR TITLE
Correctly type describe_images_owners in config

### DIFF
--- a/src/aec/util/config.py
+++ b/src/aec/util/config.py
@@ -1,6 +1,6 @@
 import os.path
 from argparse import Namespace
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, List, Union
 
 import pytoml as toml
 from typing_extensions import TypedDict
@@ -26,7 +26,7 @@ class Config(TypedDict, total=False):
     additional_tags: Dict[str, str]
     iam_instance_profile_arn: str
     kms_key_id: str
-    describe_images_owners: str
+    describe_images_owners: Union[List[str], str]
     describe_images_name_match: str
 
 


### PR DESCRIPTION
The describe_images_owners key is either a string or a List of string. Logic for both cases is in https://github.com/seek-oss/aec/blob/master/src/aec/command/ami.py#L76-L83, and usage is illustrated by the example at https://github.com/seek-oss/aec/blob/master/src/aec/config-example/ec2.toml.

This fix is required on my side to allow easily reading the AEC conf with pydantic.