### PR TITLE
build: fix tagging again

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -47,7 +47,7 @@ jobs:
       run: make publish
     - name: Read version
       if: steps.version-bump.outputs.changed == 'true'
-      run: echo "version=$(python -c 'import aec;print(aec.__version__)')" >> $GITHUB_ENV
+      run: echo "version=$(.venv/bin/python -c 'import aec;print(aec.__version__)')" >> $GITHUB_ENV
     - name: Tag commit
       if: steps.version-bump.outputs.changed == 'true'
       uses: tvdias/github-tagger@v0.0.1


### PR DESCRIPTION
the fix in #375 didn't work.. from the [failed build](https://github.com/seek-oss/aec/runs/7606810567?check_suite_focus=true#step:10:10):
```
Run echo "version=$(python -c 'import aec;print(aec.__version__)')" >> $GITHUB_ENV
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'aec'
```