### PR TITLE
docs: use cog to generate ec2 describe docs

### DIFF
--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -1,13 +1,16 @@
+<!-- [[[cog
+import cog
+import aec.util.docs as docs
+]]] -->
+<!-- [[[end]]] -->
 # EC2 Usage
 
 Run `aec ec2 -h` for help:
 
 <!-- [[[cog
-import cog
 from aec.main import build_parser
 cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ec2'].format_help()}```")
 ]]] -->
-
 ```
 usage: aec ec2 [-h] {create-key-pair,describe,launch,logs,modify,start,stop,tag,tags,status,templates,terminate,user-data} ...
 
@@ -30,7 +33,6 @@ subcommands:
     terminate           Terminate EC2 instance.
     user-data           Describe user data for an instance.
 ```
-
 <!-- [[[end]]] -->
 
 Launch an instance named `food baby` from the [ec2 launch template](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-launch-templates.html) named `yummy`:
@@ -150,14 +152,17 @@ vol-0439c5ed37f6d455e,awesome-vol,"Name=awesome-vol, Owner=jane"
 
 Show instances status checks:
 
+<!-- [[[cog
+cog.out(f"```\n{docs.status()}```")
+]]] -->
 ```
-aec ec2 status
-
-  InstanceId            State     Name    System status check   Instance status check
- ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-178f32b2857e1ee7f   running   alice   reachability passed   reachability passed
-  i-fa8cba40e84f2afae   running   sam     reachability passed   reachability failed since 2022-03-27 03:17:00+00:00
+                                                                                       
+  InstanceId            State     Name    System status check   Instance status check  
+ ───────────────────────────────────────────────────────────────────────────────────── 
+  i-e37da9f78cf7bc0cf   running   alice   reachability passed   reachability passed    
+                                                                                       
 ```
+<!-- [[[end]]] -->
 
 Terminate an instance using its id:
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -1,8 +1,11 @@
 <!-- [[[cog
 import cog
-import aec.util.docs as docs
+from aec.util.docgen import docs
+from aec.util.docgen import mock_aws_config as config
+import aec.command.ec2 as ec2
 ]]] -->
 <!-- [[[end]]] -->
+
 # EC2 Usage
 
 Run `aec ec2 -h` for help:
@@ -61,16 +64,19 @@ aec ec2 modify "lady gaga" p2.xlarge
 
 List all instances in the region:
 
+<!-- [[[cog
+cog.out(f"```\n{docs('aec ec2 describe', ec2.describe(config))}```")
+]]] -->
 ```
 aec ec2 describe
-
-  InstanceId            State     Name    Type       DnsName                   LaunchTime                 ImageId
- ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-db2e4e24c95fa5ed7   running   alice   t3.small   ec2-54-214-178-132.com…   2022-02-09                 ami-03cf127a
-                                                                               09:46:44+00:00
-  i-a91307a999f4309be   running   sam     t3.small   ec2-54-214-170-196.com…   2022-02-09                 ami-03cf127a
-                                                                               09:46:44+00:00
+                                                                                                                                                         
+  InstanceId            State     Name    Type       DnsName                                                   LaunchTime                  ImageId       
+ ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+  i-e6beeeda8a61d68d6   running   alice   t3.small   ec2-54-214-207-11.ap-southeast-2.compute.amazonaws.com    2022-11-01 02:47:31+00:00   ami-03cf127a  
+  i-979653d69dda02aba   running   sam     t3.small   ec2-54-214-240-218.ap-southeast-2.compute.amazonaws.com   2022-11-01 02:47:32+00:00   ami-03cf127a  
+                                                                                                                                                         
 ```
+<!-- [[[end]]] -->
 
 List instances containing `gaga` in the name:
 
@@ -152,17 +158,14 @@ vol-0439c5ed37f6d455e,awesome-vol,"Name=awesome-vol, Owner=jane"
 
 Show instances status checks:
 
-<!-- [[[cog
-cog.out(f"```\n{docs.status()}```")
-]]] -->
 ```
-                                                                                       
-  InstanceId            State     Name    System status check   Instance status check  
- ───────────────────────────────────────────────────────────────────────────────────── 
-  i-e37da9f78cf7bc0cf   running   alice   reachability passed   reachability passed    
-                                                                                       
+aec ec2 status
+
+  InstanceId            State     Name    System status check   Instance status check
+ ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  i-178f32b2857e1ee7f   running   alice   reachability passed   reachability passed
+  i-fa8cba40e84f2afae   running   sam     reachability passed   reachability failed since 2022-03-27 03:17:00+00:00
 ```
-<!-- [[[end]]] -->
 
 Terminate an instance using its id:
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -69,12 +69,12 @@ cog.out(f"```\n{docs('aec ec2 describe', ec2.describe(config))}```")
 ]]] -->
 ```
 aec ec2 describe
-                                                                                                                                                         
-  InstanceId            State     Name    Type       DnsName                                                   LaunchTime                  ImageId       
- ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+
+  InstanceId            State     Name    Type       DnsName                                                   LaunchTime                  ImageId  
+ ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   i-e6beeeda8a61d68d6   running   alice   t3.small   ec2-54-214-207-11.ap-southeast-2.compute.amazonaws.com    2022-11-01 02:47:31+00:00   ami-03cf127a  
   i-979653d69dda02aba   running   sam     t3.small   ec2-54-214-240-218.ap-southeast-2.compute.amazonaws.com   2022-11-01 02:47:32+00:00   ami-03cf127a  
-                                                                                                                                                         
+
 ```
 <!-- [[[end]]] -->
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -65,16 +65,14 @@ aec ec2 modify "lady gaga" p2.xlarge
 List all instances in the region:
 
 <!-- [[[cog
-cog.out(f"```\n{docs('aec ec2 describe', ec2.describe(config))}```")
+cog.out(f"```\n{docs('aec ec2 describe', ec2.describe(config))}\n```")
 ]]] -->
 ```
 aec ec2 describe
-
-  InstanceId            State     Name    Type       DnsName                                                   LaunchTime                  ImageId  
+InstanceId            State     Name    Type       DnsName                                                   LaunchTime                  ImageId  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-e6beeeda8a61d68d6   running   alice   t3.small   ec2-54-214-207-11.ap-southeast-2.compute.amazonaws.com    2022-11-01 02:47:31+00:00   ami-03cf127a  
-  i-979653d69dda02aba   running   sam     t3.small   ec2-54-214-240-218.ap-southeast-2.compute.amazonaws.com   2022-11-01 02:47:32+00:00   ami-03cf127a  
-
+  i-c42573a4089b65678   running   alice   t3.small   ec2-54-214-215-234.ap-southeast-2.compute.amazonaws.com   2022-11-01 02:59:34+00:00   ami-03cf127a  
+  i-8c7eeff04f15670a8   running   sam     t3.small   ec2-54-214-57-59.ap-southeast-2.compute.amazonaws.com     2022-11-01 02:59:36+00:00   ami-03cf127a
 ```
 <!-- [[[end]]] -->
 

--- a/docs/ssm.md
+++ b/docs/ssm.md
@@ -7,7 +7,6 @@ import cog
 from aec.main import build_parser
 cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ssm'].format_help()}```")
 ]]] -->
-
 ```
 usage: aec ssm [-h] {commands,compliance-summary,describe,invocations,output,patch,patch-summary,run} ...
 
@@ -25,7 +24,6 @@ subcommands:
     patch-summary       Patch summary for all instances that have run the patch baseline.
     run                 Run a shell script on instance(s). Script is read from stdin.
 ```
-
 <!-- [[[end]]] -->
 
 ## Examples

--- a/docs/ssm.md
+++ b/docs/ssm.md
@@ -7,6 +7,7 @@ import cog
 from aec.main import build_parser
 cog.out(f"```\n{build_parser()._subparsers._actions[1].choices['ssm'].format_help()}```")
 ]]] -->
+
 ```
 usage: aec ssm [-h] {commands,compliance-summary,describe,invocations,output,patch,patch-summary,run} ...
 
@@ -24,6 +25,7 @@ subcommands:
     patch-summary       Patch summary for all instances that have run the patch baseline.
     run                 Run a shell script on instance(s). Script is read from stdin.
 ```
+
 <!-- [[[end]]] -->
 
 ## Examples
@@ -55,15 +57,28 @@ List all commands
 
 ```
 aec ssm commands
-  RequestedDateTime   CommandId                              Status     DocumentName           Operation   # target   # error   # timeout   # complete  
+  RequestedDateTime   CommandId                              Status     DocumentName           Operation   # target   # error   # timeout   # complete
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  2022-08-27 15:10    6dc4699b-f9f2-43b5-8d46-314eaf11b8dc   Failed     AWS-RunPatchBaseline   Install     60         3                     60  
-  2022-08-26 22:15    3f12a15e-9149-4f55-a4ad-998fc8f731bb   Success    AWS-RunPatchBaseline   Scan        1                                1  
+  2022-08-27 15:10    6dc4699b-f9f2-43b5-8d46-314eaf11b8dc   Failed     AWS-RunPatchBaseline   Install     60         3                     60
+  2022-08-26 22:15    3f12a15e-9149-4f55-a4ad-998fc8f731bb   Success    AWS-RunPatchBaseline   Scan        1                                1
+```
+
+Invocations of a command
+
+```
+aec ssm invocations 6dc4699b-f9f2-43b5-8d46-314eaf11b8dc
+```
+
+Invocations of a command, with output formatted using [xsv](https://github.com/BurntSushi/xsv) so ConsoleLink is visible:
+
+```
+aec ssm invocations 6dc4699b-f9f2-43b5-8d46-314eaf11b8dc -o csv | xsv select Name,StatusDetails,ConsoleLink | xsv table
 ```
 
 Patch summary for all instances (that have run the patch baseline):
 
 ```
+aec ssm patch-summary
   InstanceId            Name                            Needed   Pending Reboot   Errored   Rejected   Last operation time         Last operation
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   i-01579de1b005846cb   awesome-instance                                                               2021-06-04 23:13:56+10:00   Scan
@@ -73,7 +88,7 @@ Patch summary for all instances (that have run the patch baseline):
 Compliance status of running instances (that have run the patch baseline):
 
 ```
-ssm compliance-summary
+aec ssm compliance-summary
 
   InstanceId            Name                    Status          NonCompliantCount   Last operation time
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -180,7 +180,7 @@ def describe(
     include_terminated: bool = False,
     show_running_only: bool = False,
     sort_by: str = "State,Name",
-    columns: Optional[str] = None,
+    columns: str = "InstanceId,State,Name,Type,DnsName,LaunchTime,ImageId",
 ) -> List[Instance]:
     """List EC2 instances in the region."""
 
@@ -194,7 +194,7 @@ def describe(
 
     # print(response["Reservations"][0]["Instances"][0])
 
-    cols = columns.split(",") if columns else ["InstanceId", "State", "Name", "Type", "DnsName"]
+    cols = columns.split(",")
 
     # don't sort by cols we aren't showing
     sort_cols = [sc for sc in sort_by.split(",") if sc in cols]

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -13,7 +13,7 @@ import aec.util.cli as cli
 import aec.util.config as config
 import aec.util.configure as configure
 import aec.util.display as display
-from aec.util.cli import Arg, Cmd
+from aec.util.cli import Arg, Cmd, parameter_defaults
 from aec.util.errors import HandledError
 
 config_arg = Arg("--config", help="Section of the config file to use")
@@ -52,8 +52,8 @@ ec2_cli = [
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-r", "--show-running-only", action='store_true', help="Show running or pending instances only"),
         Arg("-it", "--include-terminated", action='store_true', help="Include terminated instances"),
-        Arg("-s", "--sort-by", type=str, help="Sort by one or more fields", default="State,Name"),
-        Arg("-c", "--columns", type=str, help="Customise the columns shown", default="InstanceId,State,Name,Type,DnsName,LaunchTime,ImageId"),
+        Arg("-s", "--sort-by", type=str, help="Sort by one or more fields", default=parameter_defaults(ec2.describe)["sort_by"]),
+        Arg("-c", "--columns", type=str, help="Customise the columns shown", default=parameter_defaults(ec2.describe)["columns"]),
     ]),
     Cmd(ec2.launch, [
         config_arg,

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -2,7 +2,7 @@
 
 import inspect
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace, _SubParsersAction
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from aec.util.display import OutputFormat
 
@@ -101,3 +101,16 @@ def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat
         delattr(pargs, "output")
 
     return (call_me(**vars(pargs)), output_format)
+
+
+def parameter_defaults(func: Callable) -> Dict[str, Any]:
+    """Get a function's parameter defaults.
+
+    Args:
+        func (Callable): function
+
+    Returns:
+        Dict[str, Any]: Dictionary of parameter name => default value or None
+    """
+    signature = inspect.signature(func)
+    return {k: v.default for k, v in signature.parameters.items() if v.default is not inspect.Parameter.empty}

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -104,7 +104,8 @@ def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat
 
 
 def parameter_defaults(func: Callable) -> Dict[str, Any]:
-    """Get a function's parameter defaults.
+    """
+    Get a function's parameter defaults.
 
     Args:
         func (Callable): function

--- a/src/aec/util/display.py
+++ b/src/aec/util/display.py
@@ -39,7 +39,7 @@ def as_strings(values: Iterable[Any]) -> List[str]:
 
 def pretty_print(
     result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,
-    output_format: OutputFormat,
+    output_format: OutputFormat = OutputFormat.table,
 ) -> None:
     """print results as table/csv/json."""
 

--- a/src/aec/util/docgen.py
+++ b/src/aec/util/docgen.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import io
+from contextlib import redirect_stdout
 from typing import Any, Dict, Iterator, List
-from aec.util.config import Config
+
 from moto import mock_ec2
-from moto.ec2.models.amis import AMIS
 from moto.ec2 import ec2_backends
+from moto.ec2.models.amis import AMIS
+
 import aec.command.ec2 as ec2
 import aec.util.display as display
-from contextlib import redirect_stdout
-import io
-
+from aec.util.config import Config
 
 # fixtures
 mock_ec2().start()
@@ -30,7 +31,10 @@ ec2.launch(mock_aws_config, "alice", ami_id)
 ec2.launch(mock_aws_config, "sam", ami_id)
 
 
-def docs(cmd_name: str, result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,):
+def docs(
+    cmd_name: str,
+    result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,
+) -> str:
     capture = io.StringIO()
     with redirect_stdout(capture):
         display.pretty_print(result)

--- a/src/aec/util/docgen.py
+++ b/src/aec/util/docgen.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List
 from aec.util.config import Config
 from moto import mock_ec2
 from moto.ec2.models.amis import AMIS
@@ -6,6 +9,7 @@ import aec.command.ec2 as ec2
 import aec.util.display as display
 from contextlib import redirect_stdout
 import io
+
 
 # fixtures
 mock_ec2().start()
@@ -23,11 +27,11 @@ mock_aws_config: Config = {
 ami_id = AMIS[0]["ami_id"]
 
 ec2.launch(mock_aws_config, "alice", ami_id)
+ec2.launch(mock_aws_config, "sam", ami_id)
 
 
-def describe():
+def docs(cmd_name: str, result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,):
     capture = io.StringIO()
     with redirect_stdout(capture):
-        result = ec2.describe(mock_aws_config)
         display.pretty_print(result)
-    return capture.getvalue()
+    return f"{cmd_name}\n{capture.getvalue()}"

--- a/src/aec/util/docgen.py
+++ b/src/aec/util/docgen.py
@@ -38,4 +38,4 @@ def docs(
     capture = io.StringIO()
     with redirect_stdout(capture):
         display.pretty_print(result)
-    return f"{cmd_name}\n{capture.getvalue()}"
+    return f"{cmd_name}\n{capture.getvalue().strip()}"

--- a/src/aec/util/docs.py
+++ b/src/aec/util/docs.py
@@ -25,9 +25,9 @@ ami_id = AMIS[0]["ami_id"]
 ec2.launch(mock_aws_config, "alice", ami_id)
 
 
-def status():
+def describe():
     capture = io.StringIO()
     with redirect_stdout(capture):
-        result = ec2.status(mock_aws_config)
+        result = ec2.describe(mock_aws_config)
         display.pretty_print(result)
     return capture.getvalue()

--- a/src/aec/util/docs.py
+++ b/src/aec/util/docs.py
@@ -1,0 +1,33 @@
+from aec.util.config import Config
+from moto import mock_ec2
+from moto.ec2.models.amis import AMIS
+from moto.ec2 import ec2_backends
+import aec.command.ec2 as ec2
+import aec.util.display as display
+from contextlib import redirect_stdout
+import io
+
+# fixtures
+mock_ec2().start()
+region = "ap-southeast-2"
+mock_aws_config: Config = {
+    "region": region,
+    "key_name": "test_key",
+    "vpc": {
+        "name": "test vpc",
+        "subnet": next(ec2_backends[region].get_all_subnets()).id,
+        "security_group": "default",
+    },
+    "iam_instance_profile_arn": "test_profile",
+}
+ami_id = AMIS[0]["ami_id"]
+
+ec2.launch(mock_aws_config, "alice", ami_id)
+
+
+def status():
+    capture = io.StringIO()
+    with redirect_stdout(capture):
+        result = ec2.status(mock_aws_config)
+        display.pretty_print(result)
+    return capture.getvalue()

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -25,10 +25,11 @@ from aec.command.ec2 import (
     user_data,
     volume_tags,
 )
+from aec.util.config import Config
 
 
 @pytest.fixture
-def mock_aws_config():
+def mock_aws_config() -> Config:
     mock = mock_ec2()
     mock.start()
     region = "ap-southeast-2"


### PR DESCRIPTION
also now derives cli argparser defaults from function parameter defaults to avoid drift (I discovered the drift when running `ec2 describe` via cog)