### PR TITLE
feat: python 3.7 is now the minimal version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["AWS", "EC2", "command line", "cli"]
 classifiers = ["License :: OSI Approved :: MIT License"]
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 dependencies = [
     "boto3==1.24.41",
     "importlib_resources==5.9.0",
@@ -31,7 +31,7 @@ dev = [
     "pyfakefs~=4.6",
     "pytest~=7.1",
     "pytest-mock~=3.8",
-    "ruff~=0.0.226",
+    "ruff~=0.0.235",
     "twine~=4.0",
 ]
 
@@ -84,7 +84,7 @@ select = [
     # flake8-unused-arguments
     "ARG",
     # pyupgrade
-    "UP"
+    "UP",
 ]
 ignore = [
     # allow untyped self and cls args, and no return type from dunder methods
@@ -96,10 +96,13 @@ ignore = [
 ]
 # first-party imports for sorting
 src = ["src"]
-
+# pyupgrade target
+target-version = "py37"
 fix = true
 
-target-version = "py36"
+[tool.ruff.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.ruff.per-file-ignores]
 # imports in __init__.py don't need to be used in __init__.py


### PR DESCRIPTION
[ruff now only supports 3.7+](https://github.com/charliermarsh/ruff/pull/2159) and errors with a lower target version

Dropping python 3.6 support is OK, as it's [EOL](https://endoflife.date/python), and no longer a supported AWS Lambda runtime. It still ships with Ubuntu 18.04 but that is [EOL in April 2023](https://canonical.com/blog/ubuntu-18-04-lts-end-of-life-keep-your-fleet-of-devices-up-and-running). 
