### PR TITLE
refactor: rename name to ident

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,11 +21,15 @@ autolabeler:
       - '/ci/i'
       - '/refactor/i'
 
+# draft release title & tag
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+
 # release notes template
 template: |
   $CHANGES
 
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...$RESOLVED_VERSION
 
 # $CHANGES are categorised by these PR labels
 categories:

--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -51,7 +51,7 @@ def fetch(config: Config, ami: str) -> Image:
     else:
         try:
             # lookup by ami id
-            ami_details = describe(config, name=ami)[0]
+            ami_details = describe(config, ident=ami)[0]
         except IndexError:
             raise RuntimeError(f"Could not find {ami}") from None
     return ami_details
@@ -59,14 +59,14 @@ def fetch(config: Config, ami: str) -> Image:
 
 def _describe_images(
     config: Config,
-    name_or_id: Optional[str] = None,
+    ident: Optional[str] = None,
     owner: Optional[str] = None,
     name_match: Optional[str] = None,
 ) -> DescribeImagesResultTypeDef:
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
-    if name_or_id and name_or_id.startswith("ami-"):
-        return ec2_client.describe_images(ImageIds=[name_or_id])
+    if ident and ident.startswith("ami-"):
+        return ec2_client.describe_images(ImageIds=[ident])
     if owner:
         owners_filter = [owner]
     else:
@@ -83,8 +83,8 @@ def _describe_images(
         name_match = config.get("describe_images_name_match", None)
 
     if name_match is None:
-        filters = [{"Name": "name", "Values": [f"{name_or_id}"]}] if name_or_id else []
-        match_desc = f" named {name_or_id}" if name_or_id else ""
+        filters = [{"Name": "name", "Values": [f"{ident}"]}] if ident else []
+        match_desc = f" named {ident}" if ident else ""
     else:
         filters: List[FilterTypeDef] = [{"Name": "name", "Values": [f"*{name_match}*"]}]
         match_desc = f" with name containing {name_match}"
@@ -96,14 +96,14 @@ def _describe_images(
 
 def describe(
     config: Config,
-    name: Optional[str] = None,
+    ident: Optional[str] = None,
     owner: Optional[str] = None,
     name_match: Optional[str] = None,
     show_snapshot_id: bool = False,
 ) -> List[Image]:
     """List AMIs."""
 
-    response = _describe_images(config, name, owner, name_match)
+    response = _describe_images(config, ident, owner, name_match)
 
     images = []
     for i in response["Images"]:
@@ -123,14 +123,14 @@ def describe(
 
 def describe_tags(
     config: Config,
-    name: Optional[str] = None,
+    ident: Optional[str] = None,
     owner: Optional[str] = None,
     name_match: Optional[str] = None,
     keys: Sequence[str] = [],
 ) -> List[Dict[str, Any]]:
     """List AMI images with their tags."""
 
-    response = _describe_images(config, name, owner, name_match)
+    response = _describe_images(config, ident, owner, name_match)
 
     images = []
     for i in response["Images"]:

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -48,7 +48,7 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-r", "--show-running-only", action='store_true', help="Show running or pending instances only"),
         Arg("-it", "--include-terminated", action='store_true', help="Include terminated instances"),
@@ -73,34 +73,34 @@ ec2_cli = [
     ]),
     Cmd(ec2.modify, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=str, help="Name tag of instance or instance id"),
         Arg("type", type=str, help="Type of instance")
     ]),
     Cmd(ec2.start, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=str, help="Name tag of instance or instance id"),
         Arg("-w", "--wait-ssm", action='store_true', help="Wait until the SSM agent is online before exiting"),
     ]),
     Cmd(ec2.stop, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.tag, [
         config_arg,
         Arg("-t", "--tags", type=tag_arg_checker, nargs='+', metavar="TAG", help="Tags to create in key=value form", required = True),
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH.")
     ]),
     Cmd(ec2.describe_tags, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-v", "--volumes", action='store_true', help="Show volumes"),
         Arg("-k", "--keys", type=str, nargs='*', metavar="KEY", help="Tags to display", default = []),
     ], name = "tags"),
     Cmd(ec2.status, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
     ]),
     Cmd(ec2.templates, [
@@ -108,11 +108,11 @@ ec2_cli = [
     ]),
     Cmd(ec2.terminate, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.user_data, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=str, help="Name tag of instance or instance id"),
     ]),
 ]
 
@@ -123,14 +123,14 @@ ami_cli = [
     ]),
     Cmd(ami.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to this AMI name or id"),
+        Arg("ident", type=str, nargs='?', help="Filter to this AMI name or id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
         Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
     ]),
     Cmd(ami.describe_tags, [
         config_arg,
-        Arg("id", type=str, nargs='?', help="Filter to this AMI id"),
+        Arg("ident", type=str, nargs='?', help="Filter to this AMI id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
         Arg("-k", "--keys", type=str, nargs='*', metavar="KEY", help="Tags to display", default = []),
@@ -151,14 +151,14 @@ compute_optimizer_cli = [
 ssm_cli = [
     Cmd(ssm.commands, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
     ]),
     Cmd(ssm.compliance_summary, [
         config_arg
     ]),
     Cmd(ssm.describe, [
         config_arg,
-        Arg("name", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=str, nargs='?', help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
     ]),
     Cmd(ssm.invocations, [
@@ -174,7 +174,7 @@ ssm_cli = [
     Cmd(ssm.patch, [
         config_arg,
         Arg("operation", type=str, choices=["scan", "install"], help="Scan or install"),
-        Arg("names", type=str, nargs='+', help="Name tag of instance or instance id. Use 'all' for all running instances"),
+        Arg("idents", type=str, nargs='+', help="Name tag of instance or instance id. Use 'all' for all running instances"),
         Arg("-nr","--no-reboot", action='store_true', help="Do not reboot after install"),
     ]),
     Cmd(ssm.patch_summary, [
@@ -182,7 +182,7 @@ ssm_cli = [
     ]),
     Cmd(ssm.run, [
         config_arg,
-        Arg("names", type=str, nargs='+', help="Name tags of instance or instance ids. Use 'all' for all running instances.")
+        Arg("idents", type=str, nargs='+', help="Name tags of instance or instance ids. Use 'all' for all running instances.")
     ]),
 ]
 # fmt: on

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -38,7 +38,7 @@ def test_describe_images_by_id(mock_aws_config: Config):
     # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
     canonical_account_id = "099720109477"
     mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe(config=mock_aws_config, name="ami-1e749f67")
+    images = describe(config=mock_aws_config, ident="ami-1e749f67")
 
     assert len(images) == 1
 
@@ -48,7 +48,7 @@ def test_describe_images_by_name(mock_aws_config: Config):
     # see https://github.com/spulec/moto/blob/master/moto/ec2/resources/amis.json
     canonical_account_id = "099720109477"
     mock_aws_config["describe_images_owners"] = canonical_account_id
-    images = describe(config=mock_aws_config, name="ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727")
+    images = describe(config=mock_aws_config, ident="ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727")
 
     assert len(images) == 1
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -190,7 +190,7 @@ def test_describe_by_name(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
     launch(mock_aws_config, "alex", ami_id)
 
-    instances = describe(config=mock_aws_config, name="alice")
+    instances = describe(config=mock_aws_config, ident="alice")
 
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
@@ -236,7 +236,7 @@ def test_describe_instance_id(mock_aws_config: Config):
     instances = launch(mock_aws_config, "alice", ami_id)
     instance_id = instances[0]["InstanceId"]
 
-    instances = describe(config=mock_aws_config, name=instance_id)
+    instances = describe(config=mock_aws_config, ident=instance_id)
     assert len(instances) == 1
     assert instances[0]["Name"] == "alice"
 
@@ -329,22 +329,22 @@ def test_tags_filter(mock_aws_config: Config):
 def test_stop_start(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
 
-    stop(mock_aws_config, name="alice")
+    stop(mock_aws_config, ident="alice")
 
-    start(mock_aws_config, name="alice")
+    start(mock_aws_config, ident="alice")
 
 
 def test_modify(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
 
-    instances = modify(name="alice", type="c5.2xlarge", config=mock_aws_config)
+    instances = modify(ident="alice", type="c5.2xlarge", config=mock_aws_config)
 
     instance = describe_instance0(mock_aws_config["region"], instances[0]["InstanceId"])
 
     assert instance["InstanceType"] == "c5.2xlarge"
     assert instance["EbsOptimized"] is True
 
-    instances = modify(name="alice", type="t2.medium", config=mock_aws_config)
+    instances = modify(ident="alice", type="t2.medium", config=mock_aws_config)
 
     instance = describe_instance0(mock_aws_config["region"], instances[0]["InstanceId"])
 
@@ -366,22 +366,22 @@ def test_status_match(mock_aws_config: Config):
     launch(mock_aws_config, "sam", ami_id)
 
     assert len(status(mock_aws_config)) == 2
-    assert len(status(mock_aws_config, name=instance_id)) == 1
-    assert len(status(mock_aws_config, name="alice")) == 1
+    assert len(status(mock_aws_config, ident=instance_id)) == 1
+    assert len(status(mock_aws_config, ident="alice")) == 1
     assert len(status(mock_aws_config, name_match="lic")) == 1
 
 
 def test_terminate(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
 
-    terminate(config=mock_aws_config, name="alice")
+    terminate(config=mock_aws_config, ident="alice")
 
 
 def test_terminate_empty_name_does_not_delete_all_instances(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
 
     with pytest.raises(ValueError) as exc_info:
-        terminate(config=mock_aws_config, name="")
+        terminate(config=mock_aws_config, ident="")
     print(exc_info.value.args[0])
     assert exc_info.value.args[0] == """Missing name or name_match"""
 
@@ -392,7 +392,7 @@ def test_terminate_empty_name_does_not_delete_all_instances(mock_aws_config: Con
 def test_logs(mock_aws_config: Config):
     launch(mock_aws_config, "alice", ami_id)
 
-    logs(config=mock_aws_config, name="alice")
+    logs(config=mock_aws_config, ident="alice")
 
 
 def test_ebs_encrypted_by_default(mock_aws_config: Config):
@@ -434,12 +434,12 @@ def test_user_data(mock_aws_config: Config):
         userdata=str(userdata),
     )
 
-    data = user_data(config=mock_aws_config, name="has_userdata")
+    data = user_data(config=mock_aws_config, ident="has_userdata")
     assert data == userdata.read_text()
 
 
 def test_user_data_missing(mock_aws_config: Config):
     launch(mock_aws_config, "no_userdata", ami_id)
 
-    data = user_data(config=mock_aws_config, name="no_userdata")
+    data = user_data(config=mock_aws_config, ident="no_userdata")
     assert not data


### PR DESCRIPTION
because `name` can be a `Name` tag or the object `id`

see [this discussion](https://github.com/seek-oss/aec/pull/419#discussion_r1137905001)