### PR TITLE
fix: TypeError: logs() got an unexpected keyword argument 'name'

### DIFF
--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -69,7 +69,7 @@ ec2_cli = [
     ]),
     Cmd(ec2.logs, [
         config_arg,
-        Arg("name", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=str, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.modify, [
         config_arg,


### PR DESCRIPTION
fixes:
```
❯ aec ec2 logs my-instance
Traceback (most recent call last):
  File "/Users/oliver.mannion/code/aec/.venv/bin/aec", line 8, in <module>
    sys.exit(main())
  File "/Users/oliver.mannion/code/aec/src/aec/main.py", line 213, in main
    result, output_format = cli.dispatch(build_parser(), args)
  File "/Users/oliver.mannion/code/aec/src/aec/util/cli.py", line 103, in dispatch
    return (call_me(**vars(pargs)), output_format)
TypeError: logs() got an unexpected keyword argument 'name'
```