### PR TITLE
refactor: specify venv in pyright config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,7 @@ node_modules: package.json
 
 ## pyright
 pyright: node_modules $(venv)
-# activate venv so pyright can find dependencies
-	PATH="$(venv)/bin:$$PATH" node_modules/.bin/pyright
+	node_modules/.bin/pyright
 
 ## run tests
 test: $(venv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ requires = ["setuptools", "setuptools_scm[toml]", "wheel"]
 line-length = 120
 
 [tool.pyright]
+venvPath = "."
+venv = ".venv"
 include = ["src", "tests"]
 strictListInference = true
 strictDictionaryInference = true


### PR DESCRIPTION
tell pyright where to find the venv so we don't need to have it activated for type checking to find imports

plus it looks a little cleaner