### PR TITLE
feat: `ec2 describe` can return columns about the ami

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for build checks to succeed
+      - name: Wait for build check to succeed
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.ref }}

--- a/docs/ami.md
+++ b/docs/ami.md
@@ -39,8 +39,8 @@ aec ami describe
 
   Name                                                              ImageId        CreationDate               RootDeviceName   Size  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727   ami-1e749f67   2023-04-22T03:23:51.000Z   /dev/sda1        15  
-  ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721   ami-785db401   2023-04-22T03:23:51.000Z   /dev/sda1        15
+  ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-20170727   ami-1e749f67   2023-05-27T03:17:09.000Z   /dev/sda1        15  
+  ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170721   ami-785db401   2023-05-27T03:17:09.000Z   /dev/sda1        15
 ```
 <!-- [[[end]]] -->
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -107,9 +107,9 @@ Show running instances sorted by date started (ie: LaunchTime), oldest first:
 aec ec2 describe -r -s LaunchTime
 ```
 
-Show a custom set of [columns](#columns)
+Show a custom set of [columns](#columns):
 
-<!-- [[[cog
+<!-- [[[cog 
 cog.out(f"```\n{docs('aec ec2 describe -c Name,SubnetId,Volumes,Image.CreationDate', ec2.describe(config, columns='Name,SubnetId,Volumes,Image.CreationDate'))}\n```")
 ]]] -->
 ```
@@ -208,7 +208,7 @@ Columns special to aec:
 - `Volumes` - volumes attached to the instance
 - `Image.X` - where `X` is a field from the Image, eg: `Image.CreationDate`. See more below.
 
-Instance columns [returned by the EC2 API](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#instancetypedef) you can use:
+[Instance columns](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#instancetypedef) returned by the EC2 API you can use:
 
 ```
 AmiLaunchIndex
@@ -254,7 +254,7 @@ VirtualizationType
 VpcId
 ```
 
-Image columns [returned by the EC2 API](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#imagetypedef) you can use with the `Image.` suffix:
+[Image columns](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#imagetypedef) returned by the EC2 API you can use with the `Image.` suffix:
 
 ```
 Architecture

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -76,10 +76,10 @@ cog.out(f"```\n{docs('aec ec2 describe', ec2.describe(config))}\n```")
 ```
 aec ec2 describe
 
-  InstanceId            State     Name    Type       DnsName                                     LaunchTime                  ImageId  
- ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-  i-684b60691ed6df821   running   alice   t3.small   ec2-54-214-97-187.compute-1.amazonaws.com   2023-04-22 03:23:51+00:00   ami-03cf127a  
-  i-5e2d7fc29698decd4   running   sam     t3.small   ec2-54-214-32-200.compute-1.amazonaws.com   2023-04-22 03:23:51+00:00   ami-03cf127a
+  InstanceId            State     Name    Type       DnsName                                      LaunchTime                  ImageId  
+ ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  i-cf1d572b090e417ef   running   alice   t3.small   ec2-54-214-212-170.compute-1.amazonaws.com   2023-05-27 03:17:09+00:00   ami-03cf127a  
+  i-0cbc08830d8779f3d   running   sam     t3.small   ec2-54-214-129-94.compute-1.amazonaws.com    2023-05-27 03:17:10+00:00   ami-03cf127a
 ```
 <!-- [[[end]]] -->
 
@@ -109,9 +109,18 @@ aec ec2 describe -r -s LaunchTime
 
 Show a custom set of [columns](#columns)
 
+<!-- [[[cog
+cog.out(f"```\n{docs('aec ec2 describe -c Name,SubnetId,Volumes,Image.CreationDate', ec2.describe(config, columns='Name,SubnetId,Volumes,Image.CreationDate'))}\n```")
+]]] -->
 ```
-aec ec2 describe -c Name,SubnetId,Volumes
+aec ec2 describe -c Name,SubnetId,Volumes,Image.CreationDate
+
+  Name    SubnetId          Volumes           Image.CreationDate  
+ ──────────────────────────────────────────────────────────────────────
+  alice   subnet-3f674ae5   ['Size=15 GiB']   2023-05-27T03:17:09.000Z  
+  sam     subnet-3f674ae5   ['Size=15 GiB']   2023-05-27T03:17:09.000Z
 ```
+<!-- [[[end]]] -->
 
 Show instances and all their tags:
 

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -197,8 +197,9 @@ Columns special to aec:
 - `State` - state name
 - `Type` - instance type
 - `Volumes` - volumes attached to the instance
+- `Image.X` - where `X` is a field from the Image, eg: `Image.CreationDate`. See more below.
 
-Columns returned by the EC2 API:
+Instance columns [returned by the EC2 API](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#instancetypedef) you can use:
 
 ```
 AmiLaunchIndex
@@ -242,4 +243,39 @@ UsageOperation
 UsageOperationUpdateTime
 VirtualizationType
 VpcId
+```
+
+Image columns [returned by the EC2 API](https://youtype.github.io/boto3_stubs_docs/mypy_boto3_ec2/type_defs/#imagetypedef) you can use with the `Image.` suffix:
+
+```
+Architecture
+CreationDate
+ImageId
+ImageLocation
+ImageType
+Public
+KernelId
+OwnerId
+Platform
+PlatformDetails
+UsageOperation
+ProductCodes
+RamdiskId
+State
+BlockDeviceMappings
+Description
+EnaSupport
+Hypervisor
+ImageOwnerAlias
+Name
+RootDeviceName
+RootDeviceType
+SriovNetSupport
+StateReason
+Tags
+VirtualizationType
+BootMode
+TpmSupport
+DeprecationTime
+ImdsSupport
 ```

--- a/docs/ec2.md
+++ b/docs/ec2.md
@@ -109,7 +109,7 @@ aec ec2 describe -r -s LaunchTime
 
 Show a custom set of [columns](#columns):
 
-<!-- [[[cog 
+<!-- [[[cog
 cog.out(f"```\n{docs('aec ec2 describe -c Name,SubnetId,Volumes,Image.CreationDate', ec2.describe(config, columns='Name,SubnetId,Volumes,Image.CreationDate'))}\n```")
 ]]] -->
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "boto3-stubs[ec2,compute-optimizer,ssm,s3]",
     "cogapp~=3.3",
     "darglint~=1.8",
+    "dirty-equals~=0.6",
     "moto[ec2]~=4.1",
     "pre-commit~=2.20",
     "pyfakefs~=5.1",

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -35,15 +35,20 @@ def is_ebs_optimizable(instance_type: str) -> bool:
     return not instance_type.startswith("t2")
 
 
-class Instance(TypedDict, total=False):
-    InstanceId: str
-    State: str
-    Name: Optional[str]
-    Type: str
-    DnsName: str
-    SubnetId: str
-    Volumes: List[str]
-
+Instance = TypedDict(
+    "Instance",
+    {
+        "InstanceId": "str",
+        "State": "str",
+        "Name": "Optional[str]",
+        "Type": "str",
+        "DnsName": "str",
+        "SubnetId": "str",
+        "Volumes": "List[str]",
+        "Image.CreationDate": "str",
+    },
+    total=False,
+)
 
 def launch(
     config: Config,
@@ -248,6 +253,14 @@ def describe(
 
     instances: List[Instance] = []
     while True:
+        if "Image." in columns:
+            # fetch image info
+            images_ids = [i["ImageId"] for r in response["Reservations"] for i in r["Instances"]]
+            images_response = ec2_client.describe_images(ImageIds=images_ids)
+            images_by_id = {i["ImageId"]: i for i in images_response["Images"]}
+        else:
+            images_by_id = {}
+
         for r in response["Reservations"]:
             for i in r["Instances"]:
                 if include_terminated or i["State"]["Name"] != "terminated":
@@ -264,6 +277,9 @@ def describe(
                             desc[col] = i["PublicDnsName"] or i["PrivateDnsName"]
                         elif col == "Volumes":
                             desc[col] = volumes.get(i["InstanceId"], [])
+                        elif "Image." in col:
+                            key = col.split(".")[1]
+                            desc[col] = images_by_id[i["ImageId"]][key]
                         else:
                             desc[col] = i.get(col, None)
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -280,7 +280,7 @@ def describe(
                             desc[col] = volumes.get(i["InstanceId"], [])
                         elif "Image." in col:
                             key = col.split(".")[1]
-                            desc[col] = images_by_id[i["ImageId"]][key]
+                            desc[col] = images_by_id[i["ImageId"]].get(key, None)
                         else:
                             desc[col] = i.get(col, None)
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -50,6 +50,7 @@ Instance = TypedDict(
     total=False,
 )
 
+
 def launch(
     config: Config,
     name: str,

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -1,11 +1,10 @@
-from datetime import datetime, timezone
 import os
 from pathlib import Path
 from typing import List
 
 import boto3
-from dirty_equals import IsDatetime, IsNow
 import pytest
+from dirty_equals import IsDatetime
 from moto import mock_ec2, mock_iam
 from moto.ec2 import ec2_backends
 from moto.ec2.models.amis import AMIS
@@ -248,7 +247,6 @@ def test_describe_sort_by(mock_aws_config: Config):
 
 
 def test_describe_columns(mock_aws_config: Config):
-
     launch(mock_aws_config, "sam", ami_id)
 
     del mock_aws_config["key_name"]

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List
 
 import boto3
-from dirty_equals import IsNow
+from dirty_equals import IsDatetime, IsNow
 import pytest
 from moto import mock_ec2, mock_iam
 from moto.ec2 import ec2_backends
@@ -249,10 +249,6 @@ def test_describe_sort_by(mock_aws_config: Config):
 
 def test_describe_columns(mock_aws_config: Config):
 
-    def as_datetime(dstr: str) -> datetime:
-        # Remove the "Z" character representing UTC, as it is not supported by fromisoformat()
-        return datetime.fromisoformat(dstr[:-1]).replace(tzinfo=timezone.utc)
-
     launch(mock_aws_config, "sam", ami_id)
 
     del mock_aws_config["key_name"]
@@ -268,8 +264,8 @@ def test_describe_columns(mock_aws_config: Config):
     assert "subnet" in instances[1]["SubnetId"]
     assert instances[0]["Volumes"] == ["Size=15 GiB"]
     assert instances[1]["Volumes"] == ["Size=15 GiB"]
-    assert as_datetime(instances[0]["Image.CreationDate"]) == IsNow(tz=timezone.utc)
-    assert as_datetime(instances[1]["Image.CreationDate"]) == IsNow(tz=timezone.utc)
+    assert instances[0]["Image.CreationDate"] == IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ")
+    assert instances[1]["Image.CreationDate"] == IsDatetime(format_string="%Y-%m-%dT%H:%M:%S.%fZ")
 
     # MissingKey will appear without values
     assert instances[0]["MissingKey"] is None  # type: ignore

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -250,7 +250,8 @@ def test_describe_sort_by(mock_aws_config: Config):
 def test_describe_columns(mock_aws_config: Config):
 
     def as_datetime(dstr: str) -> datetime:
-        return datetime.strptime(dstr, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
+        # Remove the "Z" character representing UTC, as it is not supported by fromisoformat()
+        return datetime.fromisoformat(dstr[:-1]).replace(tzinfo=timezone.utc)
 
     launch(mock_aws_config, "sam", ami_id)
 

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -252,7 +252,9 @@ def test_describe_columns(mock_aws_config: Config):
     del mock_aws_config["key_name"]
     launch(mock_aws_config, "alice", ami_id)
 
-    instances = describe(config=mock_aws_config, columns="SubnetId,Name,MissingKey,Volumes,Image.CreationDate")
+    instances = describe(
+        config=mock_aws_config, columns="SubnetId,Name,MissingKey,Volumes,Image.CreationDate,Image.MissingKey"
+    )
     print(instances)
 
     assert len(instances) == 2
@@ -268,6 +270,9 @@ def test_describe_columns(mock_aws_config: Config):
     # MissingKey will appear without values
     assert instances[0]["MissingKey"] is None  # type: ignore
     assert instances[1]["MissingKey"] is None  # type: ignore
+
+    assert instances[0]["Image.MissingKey"] is None  # type: ignore
+    assert instances[1]["Image.MissingKey"] is None  # type: ignore
 
 
 def describe_instance0(region_name: str, instance_id: str):


### PR DESCRIPTION
via the `Image.` prefix

eg: to see how old the image used by an instance is, use the column `Image.CreationDate`

```
aec ec2 describe -c Name,SubnetId,Volumes,Image.CreationDate

  Name    SubnetId          Volumes           Image.CreationDate  
 ──────────────────────────────────────────────────────────────────────
  alice   subnet-3f674ae5   ['Size=15 GiB']   2023-05-27T03:17:09.000Z  
  sam     subnet-3f674ae5   ['Size=15 GiB']   2023-05-27T03:17:09.000Z
```
