### PR TITLE
chore: upgrade to ruff 0.0.270

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "pyfakefs~=5.1",
     "pytest~=7.2",
     "pytest-mock~=3.8",
-    "ruff~=0.0.259",
+    "ruff~=0.0.270",
     "twine~=4.0",
 ]
 
@@ -98,10 +98,6 @@ ignore = [
 src = ["src"]
 fix = true
 show-fixes = true
-
-[tool.ruff.pyupgrade]
-# Preserve types, even if a file imports `from __future__ import annotations`.
-keep-runtime-typing = true
 
 [tool.ruff.per-file-ignores]
 # test functions don't need return types

--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List, NamedTuple, Optional, Sequence
+from typing import TYPE_CHECKING, Any, NamedTuple, Sequence
 
 import boto3
 
@@ -14,11 +14,11 @@ from aec.util.config import Config
 
 
 class Image(TypedDict):
-    Name: Optional[str]
+    Name: str | None
     ImageId: str
     CreationDate: str
-    RootDeviceName: Optional[str]
-    Size: Optional[int]
+    RootDeviceName: str | None
+    Size: int | None
     SnapshotId: NotRequired[str]
 
 
@@ -59,9 +59,9 @@ def fetch(config: Config, ami: str) -> Image:
 
 def _describe_images(
     config: Config,
-    ident: Optional[str] = None,
-    owner: Optional[str] = None,
-    name_match: Optional[str] = None,
+    ident: str | None = None,
+    owner: str | None = None,
+    name_match: str | None = None,
 ) -> DescribeImagesResultTypeDef:
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -77,7 +77,7 @@ def _describe_images(
         elif isinstance(describe_images_owners, str):
             owners_filter = [describe_images_owners]
         else:
-            owners_filter: List[str] = describe_images_owners
+            owners_filter: list[str] = describe_images_owners
 
     if name_match is None:
         name_match = config.get("describe_images_name_match", None)
@@ -86,7 +86,7 @@ def _describe_images(
         filters = [{"Name": "name", "Values": [f"{ident}"]}] if ident else []
         match_desc = f" named {ident}" if ident else ""
     else:
-        filters: List[FilterTypeDef] = [{"Name": "name", "Values": [f"*{name_match}*"]}]
+        filters: list[FilterTypeDef] = [{"Name": "name", "Values": [f"*{name_match}*"]}]
         match_desc = f" with name containing {name_match}"
 
     print(f"Describing images owned by {owners_filter}{match_desc}")
@@ -96,11 +96,11 @@ def _describe_images(
 
 def describe(
     config: Config,
-    ident: Optional[str] = None,
-    owner: Optional[str] = None,
-    name_match: Optional[str] = None,
+    ident: str | None = None,
+    owner: str | None = None,
+    name_match: str | None = None,
     show_snapshot_id: bool = False,
-) -> List[Image]:
+) -> list[Image]:
     """List AMIs."""
 
     response = _describe_images(config, ident, owner, name_match)
@@ -123,11 +123,11 @@ def describe(
 
 def describe_tags(
     config: Config,
-    ident: Optional[str] = None,
-    owner: Optional[str] = None,
-    name_match: Optional[str] = None,
+    ident: str | None = None,
+    owner: str | None = None,
+    name_match: str | None = None,
     keys: Sequence[str] = [],
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """List AMI images with their tags."""
 
     response = _describe_images(config, ident, owner, name_match)

--- a/src/aec/command/compute_optimizer.py
+++ b/src/aec/command/compute_optimizer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 import boto3
 import pytz
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 from aec.util.config import Config
 
 
-def over_provisioned(config: Config) -> List[Dict[str, Any]]:
+def over_provisioned(config: Config) -> list[dict[str, Any]]:
     """Show recommendations for over-provisioned EC2 instances."""
 
     def util(metric: UtilizationMetricTypeDef) -> str:
@@ -40,7 +40,7 @@ def over_provisioned(config: Config) -> List[Dict[str, Any]]:
     return recs
 
 
-def describe_instances_uptime(config: Config) -> Dict[str, str]:
+def describe_instances_uptime(config: Config) -> dict[str, str]:
     """List EC2 instance uptimes in the region."""
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))

--- a/src/aec/util/display.py
+++ b/src/aec/util/display.py
@@ -4,7 +4,7 @@ import csv
 import enum
 import json
 import sys
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, cast
+from typing import Any, Iterable, Iterator, List, Sequence, cast
 
 from rich import box
 from rich.console import Console
@@ -17,7 +17,7 @@ class OutputFormat(enum.Enum):
     csv = "csv"
 
 
-def as_table(dicts: Sequence[Dict[str, Any]], keys: Optional[List[str]] = None) -> List[List[Optional[str]]]:
+def as_table(dicts: Sequence[dict[str, Any]], keys: list[str] | None = None) -> list[list[str | None]]:
     """
     Converts a list of dictionaries to a list of lists (table), ordered by specified keys.
 
@@ -33,12 +33,12 @@ def as_table(dicts: Sequence[Dict[str, Any]], keys: Optional[List[str]] = None) 
     return [keys] + [[str(d.get(f, "")) if d.get(f, "") else None for f in keys] for d in dicts]  # type: ignore
 
 
-def as_strings(values: Iterable[Any]) -> List[str]:
+def as_strings(values: Iterable[Any]) -> list[str]:
     return [str(v) if v else "" for v in values]
 
 
 def pretty_print(
-    result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,
+    result: list[dict[str, Any]] | Iterator[dict[str, Any]] | dict | str | None,
     output_format: OutputFormat = OutputFormat.table,
 ) -> None:
     """print results as table/csv/json."""

--- a/src/aec/util/docgen.py
+++ b/src/aec/util/docgen.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 from contextlib import redirect_stdout
-from typing import Any, Dict, Iterator, List
+from typing import Any, Iterator
 
 from moto import mock_ec2
 from moto.ec2 import ec2_backends
@@ -32,7 +32,7 @@ ec2.launch(mock_aws_config, "sam", ami_id)
 
 def docs(
     cmd_name: str,
-    result: List[Dict[str, Any]] | Iterator[Dict[str, Any]] | Dict | str | None,
+    result: list[dict[str, Any]] | Iterator[dict[str, Any]] | dict | str | None,
 ) -> str:
     capture = io.StringIO()
     with redirect_stdout(capture):

--- a/src/aec/util/ec2.py
+++ b/src/aec/util/ec2.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Sequence
+from typing import Sequence
 
 import boto3
 
@@ -9,14 +9,12 @@ from aec.util.config import Config
 from aec.util.ec2_types import DescribeArgs
 
 
-def describe_running_instances_names(config: Config) -> Dict[str, Optional[str]]:
+def describe_running_instances_names(config: Config) -> dict[str, str | None]:
     # 2x speed up (8 -> 4 secs) compared to listing all names
     return describe_instances_names(config, {"instance-state-name": ["running"]})
 
 
-def describe_instances_names(
-    config: Config, filters: Optional[Dict[str, Sequence[str]]] = None
-) -> Dict[str, Optional[str]]:
+def describe_instances_names(config: Config, filters: dict[str, Sequence[str]] | None = None) -> dict[str, str | None]:
     """Map of EC2 instance ids to names in the region."""
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
@@ -24,7 +22,7 @@ def describe_instances_names(
     if filters:
         kwargs["Filters"] = [{"Name": k, "Values": v} for k, v in filters.items()]
 
-    instances: Dict[str, Optional[str]] = {}
+    instances: dict[str, str | None] = {}
 
     while True:
         response = ec2_client.describe_instances(**kwargs)

--- a/src/aec/util/ec2_types.py
+++ b/src/aec/util/ec2_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2.literals import InstanceTypeType, ShutdownBehaviorType
@@ -35,18 +35,18 @@ class _RequiredRunArgs(TypedDict, total=True):
 
 
 class RunArgs(_RequiredRunArgs, total=False):
-    BlockDeviceMappings: List[BlockDeviceMappingTypeDef]
+    BlockDeviceMappings: list[BlockDeviceMappingTypeDef]
     ImageId: str
     InstanceType: InstanceTypeType
     Ipv6AddressCount: int
-    Ipv6Addresses: List[InstanceIpv6AddressTypeDef]
+    Ipv6Addresses: list[InstanceIpv6AddressTypeDef]
     KernelId: str
     KeyName: str
     Monitoring: RunInstancesMonitoringEnabledTypeDef
     Placement: PlacementTypeDef
     RamdiskId: str
-    SecurityGroupIds: List[str]
-    SecurityGroups: List[str]
+    SecurityGroupIds: list[str]
+    SecurityGroups: list[str]
     SubnetId: str
     UserData: str
     AdditionalInfo: str
@@ -56,18 +56,18 @@ class RunArgs(_RequiredRunArgs, total=False):
     EbsOptimized: bool
     IamInstanceProfile: IamInstanceProfileSpecificationTypeDef
     InstanceInitiatedShutdownBehavior: ShutdownBehaviorType
-    NetworkInterfaces: List[InstanceNetworkInterfaceSpecificationTypeDef]
+    NetworkInterfaces: list[InstanceNetworkInterfaceSpecificationTypeDef]
     PrivateIpAddress: str
-    ElasticGpuSpecification: List[ElasticGpuSpecificationTypeDef]
-    ElasticInferenceAccelerators: List[ElasticInferenceAcceleratorTypeDef]
-    TagSpecifications: List[TagSpecificationTypeDef]
+    ElasticGpuSpecification: list[ElasticGpuSpecificationTypeDef]
+    ElasticInferenceAccelerators: list[ElasticInferenceAcceleratorTypeDef]
+    TagSpecifications: list[TagSpecificationTypeDef]
     LaunchTemplate: LaunchTemplateSpecificationTypeDef
     InstanceMarketOptions: InstanceMarketOptionsRequestTypeDef
     CreditSpecification: CreditSpecificationRequestTypeDef
     CpuOptions: CpuOptionsRequestTypeDef
     CapacityReservationSpecification: CapacityReservationSpecificationTypeDef
     HibernationOptions: HibernationOptionsRequestTypeDef
-    LicenseSpecifications: List[LicenseConfigurationRequestTypeDef]
+    LicenseSpecifications: list[LicenseConfigurationRequestTypeDef]
     MetadataOptions: InstanceMetadataOptionsRequestTypeDef
     EnclaveOptions: EnclaveOptionsRequestTypeDef
 

--- a/src/aec/util/tags.py
+++ b/src/aec/util/tags.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from mypy_boto3_ec2.type_defs import ImageTypeDef, InstanceTypeDef, VolumeTypeDef
 
 
-def get_value(resource: ImageTypeDef | InstanceTypeDef | VolumeTypeDef, key: str) -> Optional[str]:
+def get_value(resource: ImageTypeDef | InstanceTypeDef | VolumeTypeDef, key: str) -> str | None:
     tag_value = [t["Value"] for t in resource.get("Tags", []) if t["Key"] == key]
     return tag_value[0] if tag_value else None


### PR DESCRIPTION
includes updates to address the breaking change in https://github.com/charliermarsh/ruff/pull/4427 and fixes for the now enabled rules:
- UP006 (non-pep585-annotation)
- UP007 (non-pep604-annotation) 