### PR TITLE
fix: avoid stale creds in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def aws_credentials():
+    """Mocked AWS Credentials for moto."""
+
+    # avoid stale creds causing
+    # RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
+    del os.environ["AWS_CREDENTIAL_EXPIRATION"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,4 +9,5 @@ def aws_credentials():
 
     # avoid stale creds causing
     # RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
-    del os.environ["AWS_CREDENTIAL_EXPIRATION"]
+    if "AWS_CREDENTIAL_EXPIRATION" in os.environ:
+        del os.environ["AWS_CREDENTIAL_EXPIRATION"]


### PR DESCRIPTION
fixes:
```
make test
...
.venv/lib/python3.9/site-packages/botocore/credentials.py:547: RuntimeError
----------------------------------------------------------------------- Captured log call ------------------------------------------------------------------------
WARNING  botocore.credentials:credentials.py:546 Credentials were refreshed, but the refreshed credentials are still expired.
==================================================================== short test summary info =====================================================================
FAILED tests/test_ami.py::test_describe_images - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_describe_images_by_id - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_describe_images_by_name - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_describe_images_name_match - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_tags_image - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_delete_image - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ami.py::test_share_image - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_compute_optimizer.py::test_describe_instances_uptime - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch_template - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch_multiple_security_groups - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch_with_instance_profile - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch_no_region_specified - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_launch_with_ami_match_string - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_override_key_name - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_override_volume_size - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_config_override_volume_size - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_instance_without_tags - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_by_name - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_by_name_match - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_terminated - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_running_only - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_instance_id - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_sort_by - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_describe_columns - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_tag - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_tags - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_tags_volume - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_tags_filter - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_stop_start - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_modify - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_status - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_status_match - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_terminate - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_terminate_empty_name_does_not_delete_all_instances - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_logs - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_ebs_encrypted_by_default - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_ebs_encrypt_with_kms - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_create_key_pair - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_user_data - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ec2.py::test_user_data_missing - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
FAILED tests/test_ssm.py::test_fetch_instance_ids - RuntimeError: Credentials were refreshed, but the refreshed credentials are still expired.
============================================================ 43 failed, 8 passed, 2 skipped in 8.03s =============================================================
```