### PR TITLE
chore: bump ruff 0.0.282

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dev = [
     "pyfakefs~=5.1",
     "pytest~=7.4",
     "pytest-mock~=3.11",
-    "ruff~=0.0.277",
+    "ruff~=0.0.282",
     "twine~=4.0",
 ]
 

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -590,7 +590,7 @@ def status(
 
 
 def status_text(summary: InstanceStatusSummaryTypeDef, key: str = "reachability") -> str:
-    status = [d for d in summary["Details"] if d["Name"] == key][0]
+    status = next(d for d in summary["Details"] if d["Name"] == key)
     return f"{status['Name']} {status['Status']}" + (
         f" since {status['ImpairedSince']}" if status.get("ImpairedSince", None) else ""
     )

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import argparse
 import sys
 import traceback
-from typing import List
 
 from botocore.exceptions import ClientError, NoCredentialsError
 
@@ -208,7 +209,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(args: List[str] = sys.argv[1:]) -> None:
+def main(args: list[str] = sys.argv[1:]) -> None:
     try:
         result, output_format = cli.dispatch(build_parser(), args)
         display.pretty_print(result, output_format)

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -1,8 +1,9 @@
 """Helper functions for describing and building a CLI with command groups, which contain many subcommands."""
+from __future__ import annotations
 
 import inspect
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace, _SubParsersAction
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable
 
 from aec.util.display import OutputFormat
 
@@ -17,9 +18,9 @@ class Cmd:
     def __init__(
         self,
         call_me: Callable[..., Any],
-        args: Optional[List[Arg]] = None,
-        name: Optional[str] = None,
-        help: Optional[str] = None,
+        args: list[Arg] | None = None,
+        name: str | None = None,
+        help: str | None = None,
     ):
         # dispatch() will call this function
         self.call_me = call_me
@@ -52,8 +53,8 @@ def add_command_group(
     parent: _SubParsersAction,
     name: str,
     help: str,
-    cmds: List[Cmd],
-    args_pre_processor: Optional[Callable[[Namespace], None]] = None,
+    cmds: list[Cmd],
+    args_pre_processor: Callable[[Namespace], None] | None = None,
 ) -> None:
     group = parent.add_parser(name, help=help)
     # show help if no args provided to the command group
@@ -77,7 +78,7 @@ def add_command_group(
         )
 
 
-def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat]:
+def dispatch(parser: ArgumentParser, args: list[str]) -> tuple[Any, OutputFormat]:
     pargs = parser.parse_args(args)
 
     if "args_pre_processor" in pargs:
@@ -103,7 +104,7 @@ def dispatch(parser: ArgumentParser, args: List[str]) -> Tuple[Any, OutputFormat
     return (call_me(**vars(pargs)), output_format)
 
 
-def parameter_defaults(func: Callable) -> Dict[str, Any]:
+def parameter_defaults(func: Callable) -> dict[str, Any]:
     """
     Get a function's parameter defaults.
 

--- a/src/aec/util/config.py
+++ b/src/aec/util/config.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import os.path
 from argparse import Namespace
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable
 
 import pytoml as toml
 from typing_extensions import TypedDict
@@ -14,7 +16,7 @@ class SsmConfig(TypedDict, total=False):
 class VpcConfig(TypedDict, total=False):
     name: str
     subnet: str
-    security_group: Union[str, List[str]]
+    security_group: str | list[str]
     associate_public_ip_address: bool
 
 
@@ -24,10 +26,10 @@ class Config(TypedDict, total=False):
     key_name: str
     # the following fields are optional
     region: str
-    additional_tags: Dict[str, str]
+    additional_tags: dict[str, str]
     iam_instance_profile_arn: str
     kms_key_id: str
-    describe_images_owners: Union[List[str], str]
+    describe_images_owners: list[str] | str
     describe_images_name_match: str
     launch_template: str
     volume_size: int
@@ -45,7 +47,7 @@ def inject_config(config_file: str) -> Callable[[Namespace], None]:
 
 
 # TODO add tests for this
-def load_config(config_file: str, profile_override: Optional[str] = None) -> Config:
+def load_config(config_file: str, profile_override: str | None = None) -> Config:
     """
     Load profile from the config file.
 
@@ -74,7 +76,7 @@ def load_config(config_file: str, profile_override: Optional[str] = None) -> Con
         raise Exception(f"Missing profile {profile_override} in {config_filepath}") from None
 
 
-def load_user_config_file(config_filepath: str) -> Dict[str, Any]:
+def load_user_config_file(config_filepath: str) -> dict[str, Any]:
     if not os.path.isfile(config_filepath):
         raise Exception(f"No config file {config_filepath}")
 

--- a/src/aec/util/errors.py
+++ b/src/aec/util/errors.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 # HandledErrors are caught and their message printed without a stack trace
-from typing import Optional
 
 
 class HandledError(Exception):
@@ -7,7 +8,7 @@ class HandledError(Exception):
 
 
 class NoInstancesError(HandledError):
-    def __init__(self, name: Optional[str] = None, name_match: Optional[str] = None):
+    def __init__(self, name: str | None = None, name_match: str | None = None):
         if name:
             pretty_name = "instance id {name}" if name.startswith("i-") else f"name {name}"
             msg = f"No instances with {pretty_name}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import argparse
-from typing import Any, Dict, Optional
+from typing import Any
 
 import aec.util.cli as cli
 import aec.util.config as config
@@ -7,7 +9,7 @@ from aec.util.cli import Arg, Cmd
 
 
 def test_cli_injects_config():
-    def eat(config: Dict[str, Any], thing_one: str, temp: Optional[str] = None):
+    def eat(config: dict[str, Any], thing_one: str, temp: str | None = None):
         print(config)
         assert config and isinstance(config, dict) and config["region"]
         assert thing_one == "cheese"

--- a/tests/test_ssm.py
+++ b/tests/test_ssm.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import io
-from typing import Optional
 
 import boto3
 import pytest
@@ -25,7 +26,7 @@ def mock_aws_config():
     }
 
 
-def run_instances(client: EC2Client, name: Optional[str] = None) -> str:
+def run_instances(client: EC2Client, name: str | None = None) -> str:
     if not name:
         return client.run_instances(ImageId=AMIS[0]["ami_id"], MinCount=1, MaxCount=1)["Instances"][0]["InstanceId"]
     return client.run_instances(


### PR DESCRIPTION
Fixes:

* FA100 Missing `from __future__ import annotations`, but uses `typing.Optional`
* UP006 (non-pep585-annotation)
* UP007 (non-pep604-annotation)