### PR TITLE
ci: refactor to use ruff and black non-local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,19 +14,16 @@ repos:
     hooks:
       - id: typos
         stages: [push]
-  # vscode & the cli uses these too so they have been installed into the virtualenv
-  - repo: local
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.3.0
     hooks:
       - id: black
-        name: black
-        entry: .venv/bin/black
-        language: system
-        types: [python]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.1
+    hooks:
       - id: ruff
-        name: ruff
-        entry: .venv/bin/ruff
-        language: system
-        types: [python]
+  - repo: local
+    hooks:
       - id: pyright
         name: pyright
         entry: node_modules/.bin/pyright
@@ -34,9 +31,6 @@ repos:
         pass_filenames: false
         language: system
         types: [python]
-  # these hooks require the project's virtualenv
-  - repo: local
-    hooks:
       - id: test
         name: test
         entry: make test

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,6 @@ clean:
 ## create venv and install this package and hooks
 install: $(venv) node_modules $(if $(value CI),,install-hooks)
 
-## format all code
-format: $(venv)
-	$(venv)/bin/black .
-	$(venv)/bin/ruff .
-
 ## lint, format and type check
 check: export SKIP=test
 check: hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black~=23.1",
     "build~=0.7",
     "boto3-stubs[ec2,compute-optimizer,ssm,s3]",
     "cogapp~=3.3",
@@ -29,7 +28,6 @@ dev = [
     "pyfakefs~=5.1",
     "pytest~=7.4",
     "pytest-mock~=3.11",
-    "ruff~=0.1.1",
     "twine~=4.0",
 ]
 


### PR DESCRIPTION
to remove knowledge of .venv (which is determined by the Makefile) from the pre-commit hooks 

this also seems to be more canonical (eg: [black](https://black.readthedocs.io/en/stable/integrations/source_version_control.html), [ruff](https://github.com/astral-sh/ruff-pre-commit))

originally they were local so we could use them:
1.  in the makefile, but `make check` now calls pre-commit
1.  in vs code, which used to require they be installed in the venv, but now the [black extension](https://marketplace.visualstudio.com/items?itemName=ms-python.black-formatter) bundles a version (as the ruff extension always did)

the trade-off is that we won't have version parity between vs code and pre-commit (likewise, we don't already have this between pyright and pylance)