### PR TITLE
chore: align with python-typed-template 

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,0 +1,15 @@
+{
+  "template": "git@github.com:tekumara/python-typed-template.git",
+  "commit": "518252bdc6eaa21043b929e074a03c1da6126db2",
+  "checkout": null,
+  "context": {
+    "cookiecutter": {
+      "repo_name": "aec",
+      "package_name": "aec",
+      "project_name": "aec-cli",
+      "description": "AWS EC2 CLI",
+      "_template": "git@github.com:tekumara/python-typed-template.git"
+    }
+  },
+  "directory": null
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.eggs/
 .idea/
 .vscode/
 *.code-workspace
@@ -14,3 +15,4 @@ typings/
 pip-wheel-metadata/
 node_modules/
 .venv/
+.env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,25 @@
 # unless otherwise specified, hooks run on push only
 default_stages: [push]
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
-    hooks:
-      - id: trailing-whitespace
-        args: [--markdown-linebreak-ext=md]
-        stages: [push]
-      - id: end-of-file-fixer
-        stages: [push]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.15.5
+    rev: v1.19.0
     hooks:
       - id: typos
-        stages: [push]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.3.0
-    hooks:
-      - id: black
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.1
-    hooks:
-      - id: ruff
+  # formatters and linters are available in the virtualenv so they can be run from the makefile & vscode
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: .venv/bin/ruff check --force-exclude
+        language: system
+        types: [python]
+        require_serial: true
+      - id: ruff-format
+        name: ruff-format
+        entry: .venv/bin/ruff format
+        language: system
+        types: [python]
+        require_serial: true
       - id: pyright
         name: pyright
         entry: node_modules/.bin/pyright
@@ -33,7 +29,7 @@ repos:
         types: [python]
       - id: test
         name: test
-        entry: make test
+        entry: .venv/bin/pytest
         # run on all files
         pass_filenames: false
         language: system

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,4 @@
-MAKEFLAGS += --warn-undefined-variables
-SHELL = /bin/bash -o pipefail
-.DEFAULT_GOAL := help
-.PHONY: help install check lint pyright test install-hooks hooks docs dist publish
-
-## display help message
-help:
-	@awk '/^##.*$$/,/^[~\/\.0-9a-zA-Z_-]+:/' $(MAKEFILE_LIST) | awk '!(NR%2){print $$0p}{p=$$0}' | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort
-
-venv = .venv
-pip := $(venv)/bin/pip
-src := src tests
-
-$(pip):
-# create venv using system python even when another venv is active
-	PATH=$${PATH#$${VIRTUAL_ENV}/bin:} python3 -m venv --clear $(venv)
-	$(venv)/bin/python --version
-	$(pip) install pip~=23.0
-
-$(venv): $(if $(value CI),|,) pyproject.toml $(pip)
-	$(pip) install -e '.[dev]'
-	touch $(venv)
-
-# delete the venv
-clean:
-	rm -rf $(venv)
-
-## create venv and install this package and hooks
-install: $(venv) node_modules $(if $(value CI),,install-hooks)
-
-## lint, format and type check
-check: export SKIP=test
-check: hooks
-
-## lint and format
-lint: export SKIP=pyright,test
-lint: hooks
-
-node_modules: package.json
-	npm install --no-save
-	touch node_modules
-
-## pyright
-pyright: node_modules $(venv)
-	node_modules/.bin/pyright
-
-## run tests
-test: $(venv)
-	$(venv)/bin/pytest
+include *.mk
 
 ## generate docs
 docs: $(venv)
@@ -54,13 +6,6 @@ docs: $(venv)
 # trim trailing whitespace so hooks are happy
 	$(venv)/bin/pre-commit run --files docs/* --hook-stage push trailing-whitespace > /dev/null || true
 
-## build distribution
-dist: $(venv)
-	# start with a clean slate (see setuptools/#2347)
-	rm -rf src/*.egg-info
-	# remove previous builds
-	rm -rf dist/* build/*
-	$(venv)/bin/python -m build --sdist --wheel
 
 ## test the wheel is correctly packaged
 test-dist: tmp_dir:=$(shell mktemp -d)
@@ -69,24 +14,8 @@ test-dist: $(venv)
 	$(tmp_dir)/bin/pip install dist/*.whl
 	$(tmp_dir)/bin/aec ec2 -h
 
-## publish to pypi
-publish: $(venv)
-	$(venv)/bin/twine upload dist/*
-
 ## list outdated packages
 outdated: $(venv)
 	$(venv)/bin/pip list --outdated
 	npm outdated
 
-## run pre-commit git hooks on all files
-hooks: node_modules $(venv)
-	$(venv)/bin/pre-commit run --show-diff-on-failure --color=always --all-files --hook-stage push
-
-install-hooks: .git/hooks/pre-commit .git/hooks/pre-push
-	$(venv)/bin/pre-commit install-hooks
-
-.git/hooks/pre-commit: $(venv)
-	$(venv)/bin/pre-commit install -t pre-commit
-
-.git/hooks/pre-push: $(venv)
-	$(venv)/bin/pre-commit install -t pre-push

--- a/Makefile-common.mk
+++ b/Makefile-common.mk
@@ -1,0 +1,67 @@
+MAKEFLAGS += --warn-undefined-variables
+SHELL = /bin/bash -o pipefail
+.DEFAULT_GOAL := help
+.PHONY: help clean install format check pyright test dist hooks install-hooks
+
+## display help message
+help:
+	@awk '/^##.*$$/,/^[~\/\.0-9a-zA-Z_-]+:/' $(MAKEFILE_LIST) | awk '!(NR%2){print $$0p}{p=$$0}' | awk 'BEGIN {FS = ":.*?##"}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort
+
+venv ?= .venv
+pip := $(venv)/bin/pip
+
+$(pip): $(if $(value CI),|,) .python-version
+# create venv using system python even when another venv is active
+	PATH=$${PATH#$${VIRTUAL_ENV}/bin:} python3 -m venv --clear $(venv)
+	$(venv)/bin/python --version
+	$(pip) install --upgrade pip~=24.0
+
+$(venv): $(if $(value CI),|,) pyproject.toml $(pip)
+	$(pip) install -e '.[dev]'
+	touch $(venv)
+
+node_modules: package.json
+	npm install --no-save
+	touch node_modules
+
+# delete the venv
+clean:
+	rm -rf $(venv)
+
+## create venv and install this package and hooks
+install: $(venv) node_modules $(if $(value CI),,install-hooks)
+
+## format, lint and type check
+check: export SKIP=test
+check: hooks
+
+## format and lint
+format: export SKIP=pyright,test
+format: hooks
+
+## pyright type check
+pyright: node_modules $(venv)
+	node_modules/.bin/pyright
+
+## run tests
+test: $(venv)
+	$(venv)/bin/pytest
+
+## build python distribution
+dist: $(venv)
+	# start with a clean slate (see setuptools/#2347)
+	rm -rf dist src/*.egg-info
+	$(venv)/bin/python -m build --sdist --wheel
+
+## publish to pypi
+publish: $(venv)
+	$(venv)/bin/twine upload dist/*
+
+## run pre-commit git hooks on all files
+hooks: node_modules $(venv)
+	$(venv)/bin/pre-commit run --color=always --all-files --hook-stage push
+
+install-hooks: .git/hooks/pre-push
+
+.git/hooks/pre-push: $(venv)
+	$(venv)/bin/pre-commit install --install-hooks -t pre-push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,11 @@ dev = [
     "cogapp~=3.3",
     "dirty-equals~=0.6",
     "moto[ec2]~=5.0.2",
-    "pre-commit~=3.5",
+    "pre-commit~=3.4",
     "pyfakefs~=5.1",
     "pytest~=8.0",
     "pytest-mock~=3.11",
+    "ruff~=0.5.1",
     "twine~=5.0",
 ]
 
@@ -38,16 +39,13 @@ aec = "aec.main:main"
 homepage = "https://github.com/seek-oss/aec"
 
 [build-system]
-requires = ["setuptools", "setuptools_scm[toml]", "wheel"]
+requires = ["setuptools~=69.1", "setuptools_scm~=8.0", "wheel~=0.42"]
 
 # enable setuptools_scm to set the version based on git tags
 [tool.setuptools_scm]
 fallback_version = "0.0.0"
 
-# use PyCharm default line length of 120
 
-[tool.black]
-line-length = 120
 
 [tool.pyright]
 venvPath = "."
@@ -57,10 +55,19 @@ strictListInference = true
 strictDictionaryInference = true
 strictParameterNoneValue = true
 reportTypedDictNotRequiredAccess = false
+reportIncompatibleVariableOverride = true
+reportIncompatibleMethodOverride = true
+reportMatchNotExhaustive = true
+reportUnnecessaryTypeIgnoreComment = true
 
 [tool.ruff]
 line-length = 120
+# first-party imports for sorting
+src = ["src"]
+fix = true
+show-fixes = true
 
+[tool.ruff.lint]
 # rules to enable/ignore
 select = [
     "F",    # pyflakes
@@ -75,27 +82,29 @@ select = [
     "UP",   # pyupgrade
     "PERF", # perflint
     "RUF",  # ruff-specific
+    "SIM",  # flake8-simplify
+    "S113", # request-without-timeout
     "FA",   # flake8-future-annotations (for python 3.7/8/9)
 ]
 ignore = [
-    # allow untyped self and cls args, and no return type from dunder methods
+    # allow untyped self and cls args
     "ANN101",
     "ANN102",
+    # allow no return type from dunder methods
     "ANN204",
     # allow == True because pandas dataframes overload equality
     "E712",
 ]
-# first-party imports for sorting
-src = ["src"]
-fix = true
-show-fixes = true
+[tool.ruff.lint.isort]
+combine-as-imports = true
+force-wrap-aliases = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # test functions don't need return types
 "tests/*" = ["ANN201", "ANN202"]
 # main.py can have long lines
 "src/aec/main.py" = ["E501"]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 # allow *args: Any, **kwargs: Any
 allow-star-arg-any = true

--- a/src/aec/command/ami.py
+++ b/src/aec/command/ami.py
@@ -40,7 +40,7 @@ ami_keywords = {
 
 
 def fetch(config: Config, ami: str) -> Image:
-    ami_matcher = ami_keywords.get(ami, None)
+    ami_matcher = ami_keywords.get(ami)
     if ami_matcher:
         try:
             # lookup the latest ami by name match
@@ -112,7 +112,7 @@ def describe(
             "Name": i.get("Name", None),
             "ImageId": i["ImageId"],
             "CreationDate": i["CreationDate"],
-            "RootDeviceName": i["RootDeviceName"] if "RootDeviceName" in i else None,
+            "RootDeviceName": i.get("RootDeviceName", None),
             "Size": i["BlockDeviceMappings"][0]["Ebs"]["VolumeSize"] if i["BlockDeviceMappings"] else None,
         }
         if show_snapshot_id:

--- a/src/aec/command/compute_optimizer.py
+++ b/src/aec/command/compute_optimizer.py
@@ -68,7 +68,7 @@ def difference_in_words(date1: datetime, date2: datetime) -> str:
     if difference.hours > 0:
         words += f"{difference.hours} hours "
     if words == "":
-        if difference.minutes != 0:
+        if difference.minutes != 0:  # noqa: SIM108
             words = f"{difference.minutes} minutes"
         else:
             words = f"{difference.seconds} seconds"

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -679,6 +679,6 @@ def read_file(filepath: str) -> str:
 def read_url(url: str) -> str:
     import requests
 
-    r = requests.get(url)
+    r = requests.get(url, timeout=5)
     r.raise_for_status()
     return r.text

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -21,7 +21,7 @@ config_arg = Arg("--config", help="Section of the config file to use")
 
 
 def ami_arg_checker(s: str) -> str:
-    if not (s.startswith("ami-") or s in ami.ami_keywords.keys()):
+    if not (s.startswith("ami-") or s in ami.ami_keywords):
         raise argparse.ArgumentTypeError(f"must begin with 'ami-' or be one of {list(ami.ami_keywords.keys())}")
 
     return s
@@ -59,7 +59,7 @@ ec2_cli = [
     Cmd(ec2.launch, [
         config_arg,
         Arg("name", type=str, help="Name tag of instance"),
-        Arg("-a", "--ami", type=ami_arg_checker, help=f"AMI id or a keyword to lookup the latest ami: {[k for k in ami.ami_keywords.keys()]}"),
+        Arg("-a", "--ami", type=ami_arg_checker, help=f"AMI id or a keyword to lookup the latest ami: {list(ami.ami_keywords.keys())}"),
         Arg("-t", "--template", type=str, help="Launch template name"),
         Arg("--volume-size", type=int, help="EBS volume size (GB). Defaults to AMI volume size."),
         Arg("--encrypted", type=bool, help="Whether the EBS volume is encrypted", default=True),

--- a/src/aec/util/cli.py
+++ b/src/aec/util/cli.py
@@ -1,4 +1,5 @@
 """Helper functions for describing and building a CLI with command groups, which contain many subcommands."""
+
 from __future__ import annotations
 
 import inspect

--- a/src/aec/util/display.py
+++ b/src/aec/util/display.py
@@ -79,7 +79,7 @@ def pretty_print(
             return
 
         table = Table(box=box.SIMPLE)
-        for c in first.keys():
+        for c in first:
             table.add_column(c)
 
         table.add_row(*as_strings(first.values()))

--- a/toast.yml
+++ b/toast.yml
@@ -15,12 +15,11 @@ tasks:
       - install-node
     input_paths:
       - Makefile
+      - Makefile-common.mk
       - pyproject.toml
       - package.json
       - .pre-commit-config.yaml
-    environment:
-      # don't install hooks
-      CI: true
+      - .python-version
     command: |
       # needed so the editable package (.pth) we install points at src
       mkdir src

--- a/toast.yml
+++ b/toast.yml
@@ -23,6 +23,8 @@ tasks:
     command: |
       # needed so the editable package (.pth) we install points at src
       mkdir src
+      # needed to install hooks
+      git init . --initial-branch=main
       make install
   hooks:
     description: make hooks
@@ -35,6 +37,5 @@ tasks:
       - tests/
     command: |
       # needed for pre-commit to work and see files
-      git init . --initial-branch=main
       git add src tests
       make hooks


### PR DESCRIPTION
align with [python-typed-template](https://github.com/tekumara/python-typed-template/tree/518252bdc6eaa21043b929e074a03c1da6126db2)

ruff is now installed into the venv rather than as a pre-commit hook, reversing #443 and reintroducing knowledge of .venv into .pre-commit-config.yaml. This is advantageous until [Dependabot supports updating pre-commit hooks](https://github.com/dependabot/dependabot-core/issues/1524) and also means `ruff check .` can be run locally.

toast: install hooks during install step so they are cached 