### PR TITLE
refactor: empty string identifier guard again

### DIFF
--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -420,10 +420,6 @@ def start(
 ) -> list[Instance]:
     """Start EC2 instance."""
 
-    if not ident:
-        # avoid starting all instances when there's no name
-        raise ValueError("Missing instance identifier")
-
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     if ident.startswith("i-"):
@@ -452,10 +448,6 @@ def start(
 def stop(config: Config, ident: str) -> list[dict[str, Any]]:
     """Stop EC2 instance."""
 
-    if not ident:
-        # avoid stopping all instances when there's no name
-        raise ValueError("Missing instance identifier")
-
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     instances = describe(config, ident)
@@ -472,7 +464,8 @@ def terminate(config: Config, ident: str) -> list[dict[str, Any]]:
     """Terminate EC2 instance."""
 
     if not ident:
-        # avoid terminating all instances when there's no name
+        # avoid terminating all instances when there's no identifier
+        # we already args via arg parser, so this is defence in depth
         raise ValueError("Missing instance identifier")
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
@@ -491,10 +484,6 @@ def terminate(config: Config, ident: str) -> list[dict[str, Any]]:
 
 def modify(config: Config, ident: str, type: str) -> list[Instance]:
     """Change an instance's type."""
-    if not ident:
-        # avoid modifying all instances when there's no name
-        raise ValueError("Missing instance identifier")
-
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     instances = describe(config, ident)
@@ -543,11 +532,6 @@ def create_key_pair(config: Config, key_name: str, file_path: str) -> str:
 
 def logs(config: Config, ident: str) -> str:
     """Show the system logs."""
-
-    if not ident:
-        # avoid showing logs for all instances when there's no name
-        raise ValueError("Missing instance identifier")
-
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     instances = describe(config, ident)
@@ -690,10 +674,6 @@ def subnets(config: Config, vpc_id: str | None = None) -> list[dict[str, Any]]:
 
 def user_data(config: Config, ident: str) -> str | None:
     """Describe user data for an instance."""
-    if not ident:
-        # avoid describing all instances when there's no name
-        raise ValueError("Missing instance identifier")
-
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))
 
     instances = describe(config, ident)

--- a/src/aec/command/ec2.py
+++ b/src/aec/command/ec2.py
@@ -465,7 +465,7 @@ def terminate(config: Config, ident: str) -> list[dict[str, Any]]:
 
     if not ident:
         # avoid terminating all instances when there's no identifier
-        # we already args via arg parser, so this is defence in depth
+        # we already check args via arg parser, so this is defence in depth
         raise ValueError("Missing instance identifier")
 
     ec2_client = boto3.client("ec2", region_name=config.get("region", None))

--- a/src/aec/main.py
+++ b/src/aec/main.py
@@ -35,6 +35,12 @@ def tag_arg_checker(tag: str) -> str:
     return tag
 
 
+def non_empty(s: str) -> str:
+    if not s:
+        raise argparse.ArgumentTypeError("is empty string.")
+    return s
+
+
 # fmt: off
 
 configure_cli = [
@@ -49,7 +55,7 @@ ec2_cli = [
     ]),
     Cmd(ec2.describe, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-r", "--show-running-only", action='store_true', help="Show running or pending instances only"),
         Arg("-it", "--include-terminated", action='store_true', help="Include terminated instances"),
@@ -70,25 +76,25 @@ ec2_cli = [
     ]),
     Cmd(ec2.logs, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.modify, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id"),
         Arg("type", type=str, help="Type of instance")
     ]),
     Cmd(ec2.start, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id"),
         Arg("-w", "--wait-ssm", action='store_true', help="Wait until the SSM agent is online before exiting"),
     ]),
     Cmd(ec2.stop, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.restart, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id"),
         Arg("-t", "--type", type=str, help="Modify the instance to the given type"),
         Arg("-w", "--wait-ssm", action='store_true', help="Wait until the SSM agent is online before exiting"),
     ]),
@@ -102,25 +108,25 @@ ec2_cli = [
     ]),
     Cmd(ec2.rename, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id"),
         Arg("new_name", type=str, help="New name"),
     ]),
     Cmd(ec2.tag, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-t", "--tags", type=tag_arg_checker, action="append", metavar="TAG", help="Tags to create in key=value form. This flag can be repeated multiple times.", default = [], required = True),
     ]),
     Cmd(ec2.describe_tags, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
         Arg("-v", "--volumes", action='store_true', help="Show volumes"),
         Arg("-k", "--keys", type=str, action="append", metavar="KEY", help="Filter tags to display. This flag can be repeated multiple times.", default = []),
     ], name = "tags"),
     Cmd(ec2.status, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
     ]),
     Cmd(ec2.templates, [
@@ -128,11 +134,11 @@ ec2_cli = [
     ]),
     Cmd(ec2.terminate, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id")
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id")
     ]),
     Cmd(ec2.user_data, [
         config_arg,
-        Arg("ident", type=str, help="Name tag of instance or instance id"),
+        Arg("ident", type=non_empty, help="Name tag of instance or instance id"),
     ]),
 ]
 
@@ -143,14 +149,14 @@ ami_cli = [
     ]),
     Cmd(ami.describe, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to this AMI name or id"),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to this AMI name or id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
         Arg("--show-snapshot-id", action='store_true', help="Show snapshot id")
     ]),
     Cmd(ami.describe_tags, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to this AMI id"),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to this AMI id"),
         Arg("--owner", type=str, help="Filter to this owning account"),
         Arg("-q", type=str, dest='name_match', help="Filter to images with a name containing NAME_MATCH."),
         Arg("-k", "--keys", type=str, action="append", metavar="KEY", help="Filter tags to display. This flag can be repeated multiple times.", default = []),
@@ -171,14 +177,14 @@ compute_optimizer_cli = [
 ssm_cli = [
     Cmd(ssm.commands, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
     ]),
     Cmd(ssm.compliance_summary, [
         config_arg
     ]),
     Cmd(ssm.describe, [
         config_arg,
-        Arg("ident", type=str, nargs="?", help="Filter to instances with this Name tag or instance id."),
+        Arg("ident", type=non_empty, nargs="?", help="Filter to instances with this Name tag or instance id."),
         Arg("-q", type=str, dest='name_match', help="Filter to instances with a Name tag containing NAME_MATCH."),
     ]),
     Cmd(ssm.invocations, [


### PR DESCRIPTION
before:
```
❯ aec ec2 terminate ""
Traceback (most recent call last):
  File "/Users/oliver.mannion/code/aec/.venv/bin/aec", line 10, in <module>
    sys.exit(main())
  File "/Users/oliver.mannion/code/aec/src/aec/main.py", line 233, in main
    result, output_format = cli.dispatch(build_parser(), args)
  File "/Users/oliver.mannion/code/aec/src/aec/util/cli.py", line 105, in dispatch
    return (call_me(**vars(pargs)), output_format)
  File "/Users/oliver.mannion/code/aec/src/aec/command/ec2.py", line 476, in terminate
    raise ValueError("Missing instance identifier")
ValueError: Missing instance identifier
```

after:
```
❯ aec ec2 terminate ""
usage: aec ec2 terminate [-h] [--config CONFIG] [-o {table,csv}] ident
aec ec2 terminate: error: argument ident: is empty string
```

also simplifies the code